### PR TITLE
Adding actual logical AND, XOR, OR operators

### DIFF
--- a/Dynamic Expressions.html
+++ b/Dynamic Expressions.html
@@ -1738,7 +1738,7 @@ denotes a member.</p>
   padding:0in 5.4pt 0in 5.4pt">
   <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
   3.0pt;margin-left:0in;line-height:normal"><span class="CodeFragment">x
-  &amp; y</span></p>
+  &amp;b y</span></p>
   </td>
   <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
   none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;

--- a/Dynamic Expressions.html
+++ b/Dynamic Expressions.html
@@ -1,0 +1,2039 @@
+<html xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:w="urn:schemas-microsoft-com:office:word" xmlns:m="http://schemas.microsoft.com/office/2004/12/omml" xmlns="http://www.w3.org/TR/REC-html40"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+
+<meta name="ProgId" content="Word.Document">
+<meta name="Generator" content="Microsoft Word 12">
+<meta name="Originator" content="Microsoft Word 12">
+<link rel="File-List" href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions_files/filelist.xml">
+<title>Dynamic Expression API</title>
+<link rel="themeData" href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions_files/themedata.thmx">
+<link rel="colorSchemeMapping" href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions_files/colorschememapping.xml">
+<!--[if gte mso 9]><xml>
+ <w:WordDocument>
+  <w:SpellingState>Clean</w:SpellingState>
+  <w:GrammarState>Clean</w:GrammarState>
+  <w:TrackMoves>false</w:TrackMoves>
+  <w:TrackFormatting/>
+  <w:ValidateAgainstSchemas/>
+  <w:SaveIfXMLInvalid>false</w:SaveIfXMLInvalid>
+  <w:IgnoreMixedContent>false</w:IgnoreMixedContent>
+  <w:AlwaysShowPlaceholderText>false</w:AlwaysShowPlaceholderText>
+  <w:DoNotPromoteQF/>
+  <w:LidThemeOther>EN-US</w:LidThemeOther>
+  <w:LidThemeAsian>X-NONE</w:LidThemeAsian>
+  <w:LidThemeComplexScript>X-NONE</w:LidThemeComplexScript>
+  <w:Compatibility>
+   <w:BreakWrappedTables/>
+   <w:SnapToGridInCell/>
+   <w:WrapTextWithPunct/>
+   <w:UseAsianBreakRules/>
+   <w:DontGrowAutofit/>
+   <w:SplitPgBreakAndParaMark/>
+   <w:DontVertAlignCellWithSp/>
+   <w:DontBreakConstrainedForcedTables/>
+   <w:DontVertAlignInTxbx/>
+   <w:Word11KerningPairs/>
+   <w:CachedColBalance/>
+  </w:Compatibility>
+  <w:BrowserLevel>MicrosoftInternetExplorer4</w:BrowserLevel>
+  <m:mathPr>
+   <m:mathFont m:val="Cambria Math"/>
+   <m:brkBin m:val="before"/>
+   <m:brkBinSub m:val="--"/>
+   <m:smallFrac m:val="off"/>
+   <m:dispDef/>
+   <m:lMargin m:val="0"/>
+   <m:rMargin m:val="0"/>
+   <m:defJc m:val="centerGroup"/>
+   <m:wrapIndent m:val="1440"/>
+   <m:intLim m:val="subSup"/>
+   <m:naryLim m:val="undOvr"/>
+  </m:mathPr></w:WordDocument>
+</xml><![endif]--><!--[if gte mso 9]><xml>
+ <w:LatentStyles DefLockedState="false" DefUnhideWhenUsed="true"
+  DefSemiHidden="true" DefQFormat="false" DefPriority="99"
+  LatentStyleCount="267">
+  <w:LsdException Locked="false" Priority="0" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Normal"/>
+  <w:LsdException Locked="false" Priority="9" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="heading 1"/>
+  <w:LsdException Locked="false" Priority="9" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="heading 2"/>
+  <w:LsdException Locked="false" Priority="9" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="heading 3"/>
+  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 4"/>
+  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 5"/>
+  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 6"/>
+  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 7"/>
+  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 8"/>
+  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 9"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 1"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 2"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 3"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 4"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 5"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 6"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 7"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 8"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 9"/>
+  <w:LsdException Locked="false" Priority="35" QFormat="true" Name="caption"/>
+  <w:LsdException Locked="false" Priority="10" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Title"/>
+  <w:LsdException Locked="false" Priority="1" Name="Default Paragraph Font"/>
+  <w:LsdException Locked="false" Priority="11" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Subtitle"/>
+  <w:LsdException Locked="false" Priority="22" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Strong"/>
+  <w:LsdException Locked="false" Priority="20" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Emphasis"/>
+  <w:LsdException Locked="false" Priority="59" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Table Grid"/>
+  <w:LsdException Locked="false" UnhideWhenUsed="false" Name="Placeholder Text"/>
+  <w:LsdException Locked="false" Priority="1" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="No Spacing"/>
+  <w:LsdException Locked="false" Priority="60" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Shading"/>
+  <w:LsdException Locked="false" Priority="61" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light List"/>
+  <w:LsdException Locked="false" Priority="62" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Grid"/>
+  <w:LsdException Locked="false" Priority="63" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 1"/>
+  <w:LsdException Locked="false" Priority="64" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 2"/>
+  <w:LsdException Locked="false" Priority="65" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 1"/>
+  <w:LsdException Locked="false" Priority="66" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 2"/>
+  <w:LsdException Locked="false" Priority="67" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 1"/>
+  <w:LsdException Locked="false" Priority="68" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 2"/>
+  <w:LsdException Locked="false" Priority="69" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 3"/>
+  <w:LsdException Locked="false" Priority="70" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Dark List"/>
+  <w:LsdException Locked="false" Priority="71" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Shading"/>
+  <w:LsdException Locked="false" Priority="72" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful List"/>
+  <w:LsdException Locked="false" Priority="73" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Grid"/>
+  <w:LsdException Locked="false" Priority="60" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Shading Accent 1"/>
+  <w:LsdException Locked="false" Priority="61" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light List Accent 1"/>
+  <w:LsdException Locked="false" Priority="62" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Grid Accent 1"/>
+  <w:LsdException Locked="false" Priority="63" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 1 Accent 1"/>
+  <w:LsdException Locked="false" Priority="64" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 2 Accent 1"/>
+  <w:LsdException Locked="false" Priority="65" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 1 Accent 1"/>
+  <w:LsdException Locked="false" UnhideWhenUsed="false" Name="Revision"/>
+  <w:LsdException Locked="false" Priority="34" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="List Paragraph"/>
+  <w:LsdException Locked="false" Priority="29" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Quote"/>
+  <w:LsdException Locked="false" Priority="30" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Intense Quote"/>
+  <w:LsdException Locked="false" Priority="66" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 2 Accent 1"/>
+  <w:LsdException Locked="false" Priority="67" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 1 Accent 1"/>
+  <w:LsdException Locked="false" Priority="68" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 2 Accent 1"/>
+  <w:LsdException Locked="false" Priority="69" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 3 Accent 1"/>
+  <w:LsdException Locked="false" Priority="70" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Dark List Accent 1"/>
+  <w:LsdException Locked="false" Priority="71" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Shading Accent 1"/>
+  <w:LsdException Locked="false" Priority="72" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful List Accent 1"/>
+  <w:LsdException Locked="false" Priority="73" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Grid Accent 1"/>
+  <w:LsdException Locked="false" Priority="60" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Shading Accent 2"/>
+  <w:LsdException Locked="false" Priority="61" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light List Accent 2"/>
+  <w:LsdException Locked="false" Priority="62" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Grid Accent 2"/>
+  <w:LsdException Locked="false" Priority="63" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 1 Accent 2"/>
+  <w:LsdException Locked="false" Priority="64" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 2 Accent 2"/>
+  <w:LsdException Locked="false" Priority="65" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 1 Accent 2"/>
+  <w:LsdException Locked="false" Priority="66" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 2 Accent 2"/>
+  <w:LsdException Locked="false" Priority="67" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 1 Accent 2"/>
+  <w:LsdException Locked="false" Priority="68" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 2 Accent 2"/>
+  <w:LsdException Locked="false" Priority="69" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 3 Accent 2"/>
+  <w:LsdException Locked="false" Priority="70" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Dark List Accent 2"/>
+  <w:LsdException Locked="false" Priority="71" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Shading Accent 2"/>
+  <w:LsdException Locked="false" Priority="72" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful List Accent 2"/>
+  <w:LsdException Locked="false" Priority="73" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Grid Accent 2"/>
+  <w:LsdException Locked="false" Priority="60" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Shading Accent 3"/>
+  <w:LsdException Locked="false" Priority="61" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light List Accent 3"/>
+  <w:LsdException Locked="false" Priority="62" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Grid Accent 3"/>
+  <w:LsdException Locked="false" Priority="63" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 1 Accent 3"/>
+  <w:LsdException Locked="false" Priority="64" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 2 Accent 3"/>
+  <w:LsdException Locked="false" Priority="65" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 1 Accent 3"/>
+  <w:LsdException Locked="false" Priority="66" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 2 Accent 3"/>
+  <w:LsdException Locked="false" Priority="67" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 1 Accent 3"/>
+  <w:LsdException Locked="false" Priority="68" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 2 Accent 3"/>
+  <w:LsdException Locked="false" Priority="69" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 3 Accent 3"/>
+  <w:LsdException Locked="false" Priority="70" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Dark List Accent 3"/>
+  <w:LsdException Locked="false" Priority="71" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Shading Accent 3"/>
+  <w:LsdException Locked="false" Priority="72" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful List Accent 3"/>
+  <w:LsdException Locked="false" Priority="73" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Grid Accent 3"/>
+  <w:LsdException Locked="false" Priority="60" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Shading Accent 4"/>
+  <w:LsdException Locked="false" Priority="61" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light List Accent 4"/>
+  <w:LsdException Locked="false" Priority="62" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Grid Accent 4"/>
+  <w:LsdException Locked="false" Priority="63" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 1 Accent 4"/>
+  <w:LsdException Locked="false" Priority="64" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 2 Accent 4"/>
+  <w:LsdException Locked="false" Priority="65" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 1 Accent 4"/>
+  <w:LsdException Locked="false" Priority="66" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 2 Accent 4"/>
+  <w:LsdException Locked="false" Priority="67" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 1 Accent 4"/>
+  <w:LsdException Locked="false" Priority="68" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 2 Accent 4"/>
+  <w:LsdException Locked="false" Priority="69" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 3 Accent 4"/>
+  <w:LsdException Locked="false" Priority="70" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Dark List Accent 4"/>
+  <w:LsdException Locked="false" Priority="71" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Shading Accent 4"/>
+  <w:LsdException Locked="false" Priority="72" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful List Accent 4"/>
+  <w:LsdException Locked="false" Priority="73" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Grid Accent 4"/>
+  <w:LsdException Locked="false" Priority="60" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Shading Accent 5"/>
+  <w:LsdException Locked="false" Priority="61" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light List Accent 5"/>
+  <w:LsdException Locked="false" Priority="62" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Grid Accent 5"/>
+  <w:LsdException Locked="false" Priority="63" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 1 Accent 5"/>
+  <w:LsdException Locked="false" Priority="64" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 2 Accent 5"/>
+  <w:LsdException Locked="false" Priority="65" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 1 Accent 5"/>
+  <w:LsdException Locked="false" Priority="66" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 2 Accent 5"/>
+  <w:LsdException Locked="false" Priority="67" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 1 Accent 5"/>
+  <w:LsdException Locked="false" Priority="68" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 2 Accent 5"/>
+  <w:LsdException Locked="false" Priority="69" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 3 Accent 5"/>
+  <w:LsdException Locked="false" Priority="70" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Dark List Accent 5"/>
+  <w:LsdException Locked="false" Priority="71" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Shading Accent 5"/>
+  <w:LsdException Locked="false" Priority="72" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful List Accent 5"/>
+  <w:LsdException Locked="false" Priority="73" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Grid Accent 5"/>
+  <w:LsdException Locked="false" Priority="60" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Shading Accent 6"/>
+  <w:LsdException Locked="false" Priority="61" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light List Accent 6"/>
+  <w:LsdException Locked="false" Priority="62" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Grid Accent 6"/>
+  <w:LsdException Locked="false" Priority="63" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 1 Accent 6"/>
+  <w:LsdException Locked="false" Priority="64" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 2 Accent 6"/>
+  <w:LsdException Locked="false" Priority="65" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 1 Accent 6"/>
+  <w:LsdException Locked="false" Priority="66" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 2 Accent 6"/>
+  <w:LsdException Locked="false" Priority="67" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 1 Accent 6"/>
+  <w:LsdException Locked="false" Priority="68" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 2 Accent 6"/>
+  <w:LsdException Locked="false" Priority="69" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 3 Accent 6"/>
+  <w:LsdException Locked="false" Priority="70" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Dark List Accent 6"/>
+  <w:LsdException Locked="false" Priority="71" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Shading Accent 6"/>
+  <w:LsdException Locked="false" Priority="72" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful List Accent 6"/>
+  <w:LsdException Locked="false" Priority="73" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Grid Accent 6"/>
+  <w:LsdException Locked="false" Priority="19" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Subtle Emphasis"/>
+  <w:LsdException Locked="false" Priority="21" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Intense Emphasis"/>
+  <w:LsdException Locked="false" Priority="31" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Subtle Reference"/>
+  <w:LsdException Locked="false" Priority="32" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Intense Reference"/>
+  <w:LsdException Locked="false" Priority="33" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Book Title"/>
+  <w:LsdException Locked="false" Priority="37" Name="Bibliography"/>
+  <w:LsdException Locked="false" Priority="39" QFormat="true" Name="TOC Heading"/>
+ </w:LatentStyles>
+</xml><![endif]-->
+<style>
+<!--
+ /* Font Definitions */
+ @font-face
+	{font-family:"Cambria Math";
+	panose-1:2 4 5 3 5 4 6 3 2 4;
+	mso-font-charset:1;
+	mso-generic-font-family:roman;
+	mso-font-format:other;
+	mso-font-pitch:variable;
+	mso-font-signature:0 0 0 0 0 0;}
+@font-face
+	{font-family:Cambria;
+	panose-1:2 4 5 3 5 4 6 3 2 4;
+	mso-font-charset:0;
+	mso-generic-font-family:roman;
+	mso-font-pitch:variable;
+	mso-font-signature:-1610611985 1073741899 0 0 159 0;}
+@font-face
+	{font-family:Calibri;
+	panose-1:2 15 5 2 2 2 4 3 2 4;
+	mso-font-charset:0;
+	mso-generic-font-family:swiss;
+	mso-font-pitch:variable;
+	mso-font-signature:-1610611985 1073750139 0 0 159 0;}
+@font-face
+	{font-family:Tahoma;
+	panose-1:2 11 6 4 3 5 4 4 2 4;
+	mso-font-charset:0;
+	mso-generic-font-family:swiss;
+	mso-font-pitch:variable;
+	mso-font-signature:-520082689 -1073717157 41 0 66047 0;}
+@font-face
+	{font-family:Consolas;
+	panose-1:2 11 6 9 2 2 4 3 2 4;
+	mso-font-charset:0;
+	mso-generic-font-family:modern;
+	mso-font-pitch:fixed;
+	mso-font-signature:-1610611985 1073750091 0 0 159 0;}
+ /* Style Definitions */
+ p.MsoNormal, li.MsoNormal, div.MsoNormal
+	{mso-style-unhide:no;
+	mso-style-qformat:yes;
+	mso-style-parent:"";
+	margin-top:0in;
+	margin-right:0in;
+	margin-bottom:10.0pt;
+	margin-left:0in;
+	line-height:115%;
+	mso-pagination:widow-orphan;
+	font-size:11.0pt;
+	font-family:"Calibri","sans-serif";
+	mso-fareast-font-family:"Times New Roman";
+	mso-fareast-theme-font:minor-fareast;
+	mso-bidi-font-family:"Times New Roman";}
+h1
+	{mso-style-priority:9;
+	mso-style-unhide:no;
+	mso-style-qformat:yes;
+	mso-style-link:"Heading 1 Char";
+	margin-top:24.0pt;
+	margin-right:0in;
+	margin-bottom:0in;
+	margin-left:0in;
+	margin-bottom:.0001pt;
+	line-height:115%;
+	mso-pagination:widow-orphan;
+	page-break-after:avoid;
+	mso-outline-level:1;
+	font-size:14.0pt;
+	font-family:"Cambria","serif";
+	mso-fareast-font-family:"Times New Roman";
+	mso-fareast-theme-font:minor-fareast;
+	color:#365F91;}
+h2
+	{mso-style-priority:9;
+	mso-style-unhide:no;
+	mso-style-qformat:yes;
+	mso-style-link:"Heading 2 Char";
+	margin-top:10.0pt;
+	margin-right:0in;
+	margin-bottom:0in;
+	margin-left:0in;
+	margin-bottom:.0001pt;
+	line-height:115%;
+	mso-pagination:widow-orphan;
+	page-break-after:avoid;
+	mso-outline-level:2;
+	font-size:13.0pt;
+	font-family:"Cambria","serif";
+	mso-fareast-font-family:"Times New Roman";
+	mso-fareast-theme-font:minor-fareast;
+	color:#4F81BD;}
+h3
+	{mso-style-priority:9;
+	mso-style-unhide:no;
+	mso-style-qformat:yes;
+	mso-style-link:"Heading 3 Char";
+	margin-top:10.0pt;
+	margin-right:0in;
+	margin-bottom:0in;
+	margin-left:0in;
+	margin-bottom:.0001pt;
+	line-height:115%;
+	mso-pagination:widow-orphan;
+	page-break-after:avoid;
+	mso-outline-level:3;
+	font-size:11.0pt;
+	font-family:"Cambria","serif";
+	mso-fareast-font-family:"Times New Roman";
+	mso-fareast-theme-font:minor-fareast;
+	color:#4F81BD;}
+p.MsoListBullet, li.MsoListBullet, div.MsoListBullet
+	{mso-style-noshow:yes;
+	mso-style-priority:99;
+	margin-top:0in;
+	margin-right:0in;
+	margin-bottom:10.0pt;
+	margin-left:.25in;
+	text-indent:-.25in;
+	line-height:115%;
+	mso-pagination:widow-orphan;
+	font-size:11.0pt;
+	font-family:"Calibri","sans-serif";
+	mso-fareast-font-family:"Times New Roman";
+	mso-fareast-theme-font:minor-fareast;
+	mso-bidi-font-family:"Times New Roman";}
+a:link, span.MsoHyperlink
+	{mso-style-noshow:yes;
+	mso-style-priority:99;
+	color:blue;
+	text-decoration:underline;
+	text-underline:single;}
+a:visited, span.MsoHyperlinkFollowed
+	{mso-style-noshow:yes;
+	mso-style-priority:99;
+	color:purple;
+	text-decoration:underline;
+	text-underline:single;}
+p.MsoDocumentMap, li.MsoDocumentMap, div.MsoDocumentMap
+	{mso-style-noshow:yes;
+	mso-style-priority:99;
+	mso-style-link:"Document Map Char";
+	margin:0in;
+	margin-bottom:.0001pt;
+	mso-pagination:widow-orphan;
+	font-size:8.0pt;
+	font-family:"Tahoma","sans-serif";
+	mso-fareast-font-family:"Times New Roman";
+	mso-fareast-theme-font:minor-fareast;}
+p.MsoNoSpacing, li.MsoNoSpacing, div.MsoNoSpacing
+	{mso-style-priority:1;
+	mso-style-unhide:no;
+	mso-style-qformat:yes;
+	margin:0in;
+	margin-bottom:.0001pt;
+	mso-pagination:widow-orphan;
+	font-size:11.0pt;
+	font-family:"Calibri","sans-serif";
+	mso-fareast-font-family:"Times New Roman";
+	mso-fareast-theme-font:minor-fareast;
+	mso-bidi-font-family:"Times New Roman";}
+p.MsoListParagraph, li.MsoListParagraph, div.MsoListParagraph
+	{mso-style-priority:34;
+	mso-style-unhide:no;
+	mso-style-qformat:yes;
+	margin-top:0in;
+	margin-right:0in;
+	margin-bottom:10.0pt;
+	margin-left:.5in;
+	line-height:115%;
+	mso-pagination:widow-orphan;
+	font-size:11.0pt;
+	font-family:"Calibri","sans-serif";
+	mso-fareast-font-family:"Times New Roman";
+	mso-fareast-theme-font:minor-fareast;
+	mso-bidi-font-family:"Times New Roman";}
+span.Heading1Char
+	{mso-style-name:"Heading 1 Char";
+	mso-style-priority:9;
+	mso-style-unhide:no;
+	mso-style-locked:yes;
+	mso-style-link:"Heading 1";
+	font-family:"Cambria","serif";
+	mso-ascii-font-family:Cambria;
+	mso-hansi-font-family:Cambria;
+	color:#365F91;
+	font-weight:bold;}
+span.Heading2Char
+	{mso-style-name:"Heading 2 Char";
+	mso-style-noshow:yes;
+	mso-style-priority:9;
+	mso-style-unhide:no;
+	mso-style-locked:yes;
+	mso-style-link:"Heading 2";
+	font-family:"Cambria","serif";
+	mso-ascii-font-family:Cambria;
+	mso-hansi-font-family:Cambria;
+	color:#4F81BD;
+	font-weight:bold;}
+span.Heading3Char
+	{mso-style-name:"Heading 3 Char";
+	mso-style-noshow:yes;
+	mso-style-priority:9;
+	mso-style-unhide:no;
+	mso-style-locked:yes;
+	mso-style-link:"Heading 3";
+	font-family:"Cambria","serif";
+	mso-ascii-font-family:Cambria;
+	mso-hansi-font-family:Cambria;
+	color:#4F81BD;
+	font-weight:bold;}
+p.msolistbulletcxspfirst, li.msolistbulletcxspfirst, div.msolistbulletcxspfirst
+	{mso-style-name:msolistbulletcxspfirst;
+	mso-style-unhide:no;
+	margin-top:0in;
+	margin-right:0in;
+	margin-bottom:0in;
+	margin-left:.25in;
+	margin-bottom:.0001pt;
+	text-indent:-.25in;
+	line-height:115%;
+	mso-pagination:widow-orphan;
+	font-size:11.0pt;
+	font-family:"Calibri","sans-serif";
+	mso-fareast-font-family:"Times New Roman";
+	mso-fareast-theme-font:minor-fareast;
+	mso-bidi-font-family:"Times New Roman";}
+p.msolistbulletcxspmiddle, li.msolistbulletcxspmiddle, div.msolistbulletcxspmiddle
+	{mso-style-name:msolistbulletcxspmiddle;
+	mso-style-unhide:no;
+	margin-top:0in;
+	margin-right:0in;
+	margin-bottom:0in;
+	margin-left:.25in;
+	margin-bottom:.0001pt;
+	text-indent:-.25in;
+	line-height:115%;
+	mso-pagination:widow-orphan;
+	font-size:11.0pt;
+	font-family:"Calibri","sans-serif";
+	mso-fareast-font-family:"Times New Roman";
+	mso-fareast-theme-font:minor-fareast;
+	mso-bidi-font-family:"Times New Roman";}
+p.msolistbulletcxsplast, li.msolistbulletcxsplast, div.msolistbulletcxsplast
+	{mso-style-name:msolistbulletcxsplast;
+	mso-style-unhide:no;
+	margin-top:0in;
+	margin-right:0in;
+	margin-bottom:10.0pt;
+	margin-left:.25in;
+	text-indent:-.25in;
+	line-height:115%;
+	mso-pagination:widow-orphan;
+	font-size:11.0pt;
+	font-family:"Calibri","sans-serif";
+	mso-fareast-font-family:"Times New Roman";
+	mso-fareast-theme-font:minor-fareast;
+	mso-bidi-font-family:"Times New Roman";}
+span.DocumentMapChar
+	{mso-style-name:"Document Map Char";
+	mso-style-noshow:yes;
+	mso-style-priority:99;
+	mso-style-unhide:no;
+	mso-style-locked:yes;
+	mso-style-link:"Document Map";
+	font-family:"Tahoma","sans-serif";
+	mso-ascii-font-family:Tahoma;
+	mso-hansi-font-family:Tahoma;
+	mso-bidi-font-family:Tahoma;}
+p.msolistparagraphcxspfirst, li.msolistparagraphcxspfirst, div.msolistparagraphcxspfirst
+	{mso-style-name:msolistparagraphcxspfirst;
+	mso-style-unhide:no;
+	margin-top:0in;
+	margin-right:0in;
+	margin-bottom:0in;
+	margin-left:.5in;
+	margin-bottom:.0001pt;
+	line-height:115%;
+	mso-pagination:widow-orphan;
+	font-size:11.0pt;
+	font-family:"Calibri","sans-serif";
+	mso-fareast-font-family:"Times New Roman";
+	mso-fareast-theme-font:minor-fareast;
+	mso-bidi-font-family:"Times New Roman";}
+p.msolistparagraphcxspmiddle, li.msolistparagraphcxspmiddle, div.msolistparagraphcxspmiddle
+	{mso-style-name:msolistparagraphcxspmiddle;
+	mso-style-unhide:no;
+	margin-top:0in;
+	margin-right:0in;
+	margin-bottom:0in;
+	margin-left:.5in;
+	margin-bottom:.0001pt;
+	line-height:115%;
+	mso-pagination:widow-orphan;
+	font-size:11.0pt;
+	font-family:"Calibri","sans-serif";
+	mso-fareast-font-family:"Times New Roman";
+	mso-fareast-theme-font:minor-fareast;
+	mso-bidi-font-family:"Times New Roman";}
+p.msolistparagraphcxsplast, li.msolistparagraphcxsplast, div.msolistparagraphcxsplast
+	{mso-style-name:msolistparagraphcxsplast;
+	mso-style-unhide:no;
+	margin-top:0in;
+	margin-right:0in;
+	margin-bottom:10.0pt;
+	margin-left:.5in;
+	line-height:115%;
+	mso-pagination:widow-orphan;
+	font-size:11.0pt;
+	font-family:"Calibri","sans-serif";
+	mso-fareast-font-family:"Times New Roman";
+	mso-fareast-theme-font:minor-fareast;
+	mso-bidi-font-family:"Times New Roman";}
+p.Code, li.Code, div.Code
+	{mso-style-name:Code;
+	mso-style-unhide:no;
+	margin-top:0in;
+	margin-right:0in;
+	margin-bottom:10.0pt;
+	margin-left:.5in;
+	line-height:115%;
+	mso-pagination:widow-orphan;
+	font-size:11.0pt;
+	font-family:Consolas;
+	mso-fareast-font-family:"Times New Roman";
+	mso-fareast-theme-font:minor-fareast;
+	mso-bidi-font-family:"Times New Roman";}
+p.msopapdefault, li.msopapdefault, div.msopapdefault
+	{mso-style-name:msopapdefault;
+	mso-style-unhide:no;
+	mso-margin-top-alt:auto;
+	margin-right:0in;
+	margin-bottom:10.0pt;
+	margin-left:0in;
+	line-height:115%;
+	mso-pagination:widow-orphan;
+	font-size:12.0pt;
+	font-family:"Times New Roman","serif";
+	mso-fareast-font-family:"Times New Roman";
+	mso-fareast-theme-font:minor-fareast;}
+span.CodeFragment
+	{mso-style-name:"Code Fragment";
+	mso-style-unhide:no;
+	font-family:Consolas;
+	mso-ascii-font-family:Consolas;
+	mso-hansi-font-family:Consolas;}
+span.SpellE
+	{mso-style-name:"";
+	mso-spl-e:yes;}
+span.GramE
+	{mso-style-name:"";
+	mso-gram-e:yes;}
+.MsoChpDefault
+	{mso-style-type:export-only;
+	mso-default-props:yes;
+	font-size:10.0pt;
+	mso-ansi-font-size:10.0pt;
+	mso-bidi-font-size:10.0pt;}
+.MsoPapDefault
+	{mso-style-type:export-only;
+	margin-bottom:10.0pt;
+	line-height:115%;}
+@page Section1
+	{size:8.5in 11.0in;
+	margin:1.0in .75in 1.0in .75in;
+	mso-header-margin:.5in;
+	mso-footer-margin:.5in;
+	mso-paper-source:0;}
+div.Section1
+	{page:Section1;}
+ /* List Definitions */
+ @list l0
+	{mso-list-id:-119;
+	mso-list-type:simple;
+	mso-list-template-ids:-1170547422;}
+@list l0:level1
+	{mso-level-number-format:bullet;
+	mso-level-style-link:"List Bullet";
+	mso-level-text:\F0B7;
+	mso-level-tab-stop:.25in;
+	mso-level-number-position:left;
+	margin-left:.25in;
+	text-indent:-.25in;
+	font-family:Symbol;}
+ol
+	{margin-bottom:0in;}
+ul
+	{margin-bottom:0in;}
+-->
+</style>
+<!--[if gte mso 10]>
+<style>
+ /* Style Definitions */
+ table.MsoNormalTable
+	{mso-style-name:"Table Normal";
+	mso-tstyle-rowband-size:0;
+	mso-tstyle-colband-size:0;
+	mso-style-noshow:yes;
+	mso-style-priority:99;
+	mso-style-qformat:yes;
+	mso-style-parent:"";
+	mso-padding-alt:0in 5.4pt 0in 5.4pt;
+	mso-para-margin-top:0in;
+	mso-para-margin-right:0in;
+	mso-para-margin-bottom:10.0pt;
+	mso-para-margin-left:0in;
+	line-height:115%;
+	mso-pagination:widow-orphan;
+	font-size:10.0pt;
+	font-family:"Times New Roman","serif";}
+</style>
+<![endif]--><!--[if gte mso 9]><xml>
+ <o:shapedefaults v:ext="edit" spidmax="2050"/>
+</xml><![endif]--><!--[if gte mso 9]><xml>
+ <o:shapelayout v:ext="edit">
+  <o:idmap v:ext="edit" data="1"/>
+ </o:shapelayout></xml><![endif]-->
+</head>
+
+<body lang="EN-US" link="blue" vlink="purple" style="tab-interval:.5in">
+
+<div class="Section1">
+
+<h1><span style="mso-fareast-font-family:&quot;Times New Roman&quot;">Dynamic Expressions
+and Queries in LINQ<o:p></o:p></span></h1>
+
+<p class="MsoNormal">Database applications frequently rely on “Dynamic
+SQL”—queries that are constructed at run-time through program logic. The LINQ
+infrastructure supports similar capabilities through dynamic construction of
+expression trees using the classes in the <span class="SpellE"><span class="CodeFragment">System.Linq.Expressions</span></span> namespace. Expression
+trees are an appropriate abstraction for a variety of scenarios, but for others
+a string-based representation may be more convenient. The <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Dynamic_Expression_API">Dynamic Expression API</a> extends the core
+LINQ API with that capability. The API is located in the <span class="SpellE">Dynamic.cs</span>
+source file and provides</p>
+
+<p class="MsoListParagraph" style="text-indent:-.25in"><span style="font-family:
+Symbol">·</span><span style="font-size:7.0pt;line-height:115%;font-family:&quot;Times New Roman&quot;,&quot;serif&quot;">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><span class="GramE">Dynamic</span> parsing of strings to produce
+expression trees (the <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_The_ParseLambda_Methods"><span class="SpellE">ParseLambda</span></a>
+and <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_The_Parse_Method">Parse</a> methods),</p>
+
+<p class="MsoListParagraph" style="text-indent:-.25in"><span style="font-family:
+Symbol">·</span><span style="font-size:7.0pt;line-height:115%;font-family:&quot;Times New Roman&quot;,&quot;serif&quot;">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>Dynamic creation of “Data Classes” (the <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Dynamic_Class_Creation"><span class="SpellE">CreateClass</span></a> methods),
+and</p>
+
+<p class="MsoListParagraph" style="text-indent:-.25in"><span style="font-family:
+Symbol">·</span><span style="font-size:7.0pt;line-height:115%;font-family:&quot;Times New Roman&quot;,&quot;serif&quot;">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><span class="GramE">Dynamic</span> string-based querying through LINQ
+providers (the <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_IQueryable_Extension_Methods">IQueryable extension
+methods</a>).</p>
+
+<p class="MsoNormal">The Dynamic Expression API relies on a simple <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Expression_Language">expression language</a> for formulating
+expressions and queries in strings.</p>
+
+<h1><a name="_Dynamic_Expression_API"></a><span style="mso-fareast-font-family:
+&quot;Times New Roman&quot;">Dynamic Expression API<o:p></o:p></span></h1>
+
+<p class="MsoNormal"><a name="_The_ParseLambda_Methods"></a>The Dynamic
+Expression API is brought into scope by using (importing) the <span class="SpellE"><span class="CodeFragment">System.Linq.Dynamic</span></span>
+namespace. Below is an example of applying the Dynamic Expression API to a LINQ
+to SQL data source.</p>
+
+<p class="Code"><span class="SpellE"><span class="GramE"><span style="color:blue">var</span></span></span>
+query =<br>
+&nbsp;&nbsp;&nbsp; <span class="SpellE">db.Customers</span>.<br>
+&nbsp;&nbsp;&nbsp; <span class="GramE">Where(</span><span style="color:#A31515">"City
+= @0 and <span class="SpellE">Orders.Count</span> &gt;= @1"</span>, <span style="color:#A31515">"London"</span>, 10).<br>
+&nbsp;&nbsp;&nbsp; <span class="SpellE"><span class="GramE">OrderBy</span></span><span class="GramE">(</span><span style="color:#A31515">"<span class="SpellE">CompanyName</span>"</span>).<br>
+&nbsp;&nbsp;&nbsp; <span class="GramE">Select(</span><span style="color:#A31515">"new(<span class="SpellE">CompanyName</span> as Name, Phone)"</span>);</p>
+
+<p class="MsoNormal">Note that expressions in the query are strings that could
+have been dynamically constructed at run-time.</p>
+
+<h2><span style="mso-fareast-font-family:&quot;Times New Roman&quot;">The <span class="SpellE">ParseLambda</span> Methods<o:p></o:p></span></h2>
+
+<p class="MsoNormal">The <span class="SpellE"><span class="CodeFragment">System.Linq.Dynamic.DynamicExpression</span></span>
+class defines the following overloaded <span class="SpellE"><span class="CodeFragment">ParseLambda</span></span> methods for dynamically parsing
+and creating lambda expressions.</p>
+
+<p class="Code"><a name="ParseLambda1"></a><span class="GramE"><span style="color:blue">public</span></span> <span style="color:blue">static</span> <span class="SpellE"><span style="color:#2B91AF">LambdaExpression</span></span> <span class="SpellE">ParseLambda</span>(<br>
+&nbsp;&nbsp;&nbsp; <span class="SpellE"><span style="color:#2B91AF">ParameterExpression</span></span>[]
+parameters, <span style="color:#2B91AF">Type</span> <span class="SpellE">resultType</span>,<br>
+&nbsp;&nbsp;&nbsp; <span style="color:blue">string</span> expression, <span class="SpellE"><span style="color:blue">params</span></span> <span style="color:blue">object</span>[] values);</p>
+
+<p class="Code"><a name="ParseLambda2"></a><span class="GramE"><span style="color:blue">public</span></span> <span style="color:blue">static</span> <span class="SpellE"><span style="color:#2B91AF">LambdaExpression</span></span> <span class="SpellE">ParseLambda</span>(<br>
+&nbsp;&nbsp;&nbsp; <span style="color:#2B91AF">Type</span> <span class="SpellE">argumentType</span>,
+<span style="color:#2B91AF">Type</span> <span class="SpellE">resultType</span>,<br>
+&nbsp;&nbsp;&nbsp; <span style="color:blue">string</span> expression, <span class="SpellE"><span style="color:blue">params</span></span> <span style="color:blue">object</span>[] values);</p>
+
+<p class="Code"><a name="ParseLambda3"></a><span class="GramE"><span style="color:blue">public</span></span> <span style="color:blue">static</span> <span style="color:#2B91AF">Expression</span>&lt;<span class="SpellE"><span style="color:#2B91AF">Func</span></span>&lt;<span class="SpellE">TArgument</span>,
+<span class="SpellE">TResult</span>&gt;&gt;<br>
+&nbsp;&nbsp;&nbsp; <span class="SpellE">ParseLambda</span>&lt;<span class="SpellE">TArgument</span>,
+<span class="SpellE">TResult</span>&gt;(<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <span style="color:blue">string</span>
+expression, <span class="SpellE"><span style="color:blue">params</span></span> <span style="color:blue">object</span>[] values);</p>
+
+<p class="MsoNormal">The <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#ParseLambda1">first</a> <span class="SpellE"><span class="CodeFragment">ParseLambda</span></span> overload parses a lambda
+expression with the given <span class="CodeFragment">parameters</span> and <span class="CodeFragment">expression</span> body and returns an <span class="CodeFragment">Expression&lt;<span class="SpellE">Func</span>&lt;…&gt;&gt;</span>
+instance representing the result. If the <span class="SpellE"><span class="CodeFragment">resultType</span></span> parameter is non-null it specifies
+the required result type for the expression. The <span class="CodeFragment">values</span>
+parameter supplies zero or more <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Substitution_Values">substitution
+values</a> that may be referenced in the expression.</p>
+
+<p class="MsoNormal"><a name="LambdaExample1"></a>The example</p>
+
+<p class="Code"><span class="SpellE"><span style="color:#2B91AF">ParameterExpression</span></span>
+x = <span class="SpellE"><span style="color:#2B91AF">Expression</span>.Parameter</span>(<span class="SpellE"><span style="color:blue">typeof</span></span>(<span class="SpellE"><span style="color:blue">int</span></span>), <span style="color:#A31515">"x"</span>);<br>
+<span class="SpellE"><span style="color:#2B91AF">ParameterExpression</span></span>
+y = <span class="SpellE"><span style="color:#2B91AF">Expression</span>.Parameter</span>(<span class="SpellE"><span style="color:blue">typeof</span></span>(<span class="SpellE"><span style="color:blue">int</span></span>), <span style="color:#A31515">"y"</span>);<br>
+<span class="SpellE"><span style="color:#2B91AF">LambdaExpression</span></span> e
+= <span class="SpellE"><span style="color:#2B91AF">DynamicExpression</span>.ParseLambda</span>(<br>
+&nbsp;&nbsp;&nbsp; <span style="color:blue">new</span> <span class="SpellE"><span style="color:#2B91AF">ParameterExpression</span></span>[] { x, y }, <span style="color:blue">null</span>, <span style="color:#A31515">"(x + y) *
+2"</span>);</p>
+
+<p class="MsoNormal"><span class="GramE">creates</span> and assigns an <span class="CodeFragment">Expression&lt;<span class="SpellE">Func</span>&lt;<span class="SpellE">int</span>, <span class="SpellE">int</span>, <span class="SpellE">int</span>&gt;&gt;</span>
+instance to <span class="CodeFragment">e</span> representing the expression <span class="CodeFragment">(x</span> <span class="CodeFragment">+</span> <span class="CodeFragment">y)</span> <span class="CodeFragment">*</span> <span class="CodeFragment">2</span>. If a required result type is specified, as in</p>
+
+<p class="Code"><span class="SpellE"><span style="color:#2B91AF">LambdaExpression</span></span>
+e = <span class="SpellE"><span class="GramE"><span style="color:#2B91AF">DynamicExpression</span>.ParseLambda</span></span><span class="GramE">(</span><br>
+&nbsp;&nbsp;&nbsp; <span style="color:blue">new</span> <span class="SpellE"><span style="color:#2B91AF">ParameterExpression</span></span>[] { x, y }, <span class="SpellE"><span style="color:blue">typeof</span></span>(<span style="color:blue">double</span>), <span style="color:#A31515">"(x + y) *
+2"</span>);</p>
+
+<p class="MsoNormal"><span class="GramE">the</span> parsing operation will include
+an <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Conversions">implicit conversion</a> to the given result type, in
+this case yielding an <span class="CodeFragment">Expression&lt;<span class="SpellE">Func</span>&lt;<span class="SpellE">int</span>, <span class="SpellE">int</span>,
+double&gt;&gt;</span> instance.</p>
+
+<p class="MsoNormal">The <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#ParseLambda2">second</a> <span class="SpellE"><span class="CodeFragment">ParseLambda</span></span> overload parses a lambda
+expression with a single unnamed parameter of a specified <span class="SpellE"><span class="CodeFragment">argumentType</span></span>. This method corresponds to
+calling the first <span class="SpellE">ParseLambda</span> overload with a <span class="CodeFragment">parameters</span> argument containing a single <span class="SpellE"><span class="CodeFragment">ParameterExpression</span></span> with an
+empty or null <span class="CodeFragment">Name</span> property.</p>
+
+<p class="MsoNormal">­When parsing a lambda expression with a single unnamed
+parameter, the members of the unnamed parameter are automatically in scope in
+the expression string, and the <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Current_Instance">current instance</a>
+given by the unnamed parameter can be referenced in whole using the keyword <span class="CodeFragment">it</span>. The example</p>
+
+<p class="Code"><span class="SpellE"><span style="color:#2B91AF">LambdaExpression</span></span>
+e = <span class="SpellE"><span class="GramE"><span style="color:#2B91AF">DynamicExpression</span>.ParseLambda</span></span><span class="GramE">(</span><br>
+&nbsp;&nbsp;&nbsp; <span class="SpellE"><span style="color:blue">typeof</span></span>(<span style="color:#2B91AF">Customer</span>), <span class="SpellE"><span style="color:blue">typeof</span></span>(<span class="SpellE"><span style="color:blue">bool</span></span>),<br>
+&nbsp;&nbsp;&nbsp; <span style="color:#A31515">"City = @0 and <span class="SpellE">Orders.Count</span> &gt;= @1"</span>,<br>
+&nbsp;&nbsp;&nbsp; <span style="color:#A31515">"London"</span>, 10);</p>
+
+<p class="MsoNormal"><span class="GramE">creates</span> and assigns an <span class="CodeFragment">Expression&lt;<span class="SpellE">Func</span>&lt;Customer, <span class="SpellE">bool</span>&gt;&gt;</span> instance to <span class="CodeFragment">e</span>.
+Note that <span class="CodeFragment">City</span> and <span class="CodeFragment">Orders</span>
+are members of <span class="CodeFragment">Customer</span> that are automatically
+in scope. Also note the use of <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Substitution_Values">substitution
+values</a> to supply the constant values <span class="CodeFragment">"London"</span>
+and <span class="CodeFragment">10</span>.</p>
+
+<p class="MsoNormal">The <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#ParseLambda3">third</a> <span class="SpellE"><span class="CodeFragment">ParseLambda</span></span> overload is a <span class="SpellE">genericly</span>
+typed version of the second overload. The example below produces the same <span class="CodeFragment">Expression&lt;<span class="SpellE">Func</span>&lt;Customer, <span class="SpellE">bool</span>&gt;&gt;</span> instance as the example above, but is
+statically typed to that exact type.</p>
+
+<p class="Code"><span style="color:#2B91AF">Expression</span>&lt;<span class="SpellE"><span style="color:#2B91AF">Func</span></span>&lt;<span style="color:#2B91AF">Customer</span>, <span class="SpellE"><span style="color:blue">bool</span></span>&gt;&gt; e =<br>
+&nbsp;&nbsp;&nbsp; <span class="SpellE"><span style="color:#2B91AF">DynamicExpression</span>.ParseLambda</span>&lt;<span style="color:#2B91AF">Customer</span>, <span class="SpellE"><span style="color:blue">bool</span></span><span class="GramE">&gt;(</span><br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <span style="color:#A31515">"City
+= @0 and <span class="SpellE">Orders.Count</span> &gt;= @1"</span>,<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <span style="color:#A31515">"London"</span>,
+10);</p>
+
+<h2><a name="_The_Parse_Method"></a><span style="mso-fareast-font-family:&quot;Times New Roman&quot;">The
+Parse Method<o:p></o:p></span></h2>
+
+<p class="MsoNormal">The <span class="SpellE"><span class="CodeFragment">System.Linq.Dynamic.DynamicExpression</span></span>
+class defines the following method for parsing and creating expression tree
+fragments.</p>
+
+<p class="Code"><span class="GramE"><span style="color:blue">public</span></span> <span style="color:blue">static</span> <span style="color:#2B91AF">Expression</span>
+Parse(<span style="color:#2B91AF">Type</span> <span class="SpellE">resultType</span>,
+<span style="color:blue">string</span> expression,<br>
+&nbsp;&nbsp;&nbsp; <span class="SpellE"><span style="color:blue">params</span></span>
+<span style="color:blue">object</span>[] values);</p>
+
+<p class="MsoNormal">The Parse method parses the given <span class="CodeFragment">expression</span>
+and returns an expression tree. If the <span class="SpellE"><span class="CodeFragment">resultType</span></span> parameter is non-null it specifies
+the required result type of the expression. The <span class="CodeFragment">values</span>
+parameter supplies zero or more <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Substitution_Values">substitution
+values</a> that may be referenced in the expression.</p>
+
+<p class="MsoNormal">Unlike the <span class="SpellE"><span class="CodeFragment">ParseLambda</span></span>
+methods, the <span class="CodeFragment">Parse</span> method returns an “unbound”
+expression tree fragment. The following example uses <span class="GramE"><span class="CodeFragment">Parse</span></span> to produce the same result as a <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#LambdaExample1">previous example</a>:</p>
+
+<p class="Code"><span class="SpellE"><span style="color:#2B91AF">ParameterExpression</span></span>
+x = <span class="SpellE"><span style="color:#2B91AF">Expression</span>.Parameter</span>(<span class="SpellE"><span style="color:blue">typeof</span></span>(<span class="SpellE"><span style="color:blue">int</span></span>), <span style="color:#A31515">"x"</span>);<br>
+<span class="SpellE"><span style="color:#2B91AF">ParameterExpression</span></span>
+y = <span class="SpellE"><span style="color:#2B91AF">Expression</span>.Parameter</span>(<span class="SpellE"><span style="color:blue">typeof</span></span>(<span class="SpellE"><span style="color:blue">int</span></span>), <span style="color:#A31515">"y"</span>);<br>
+<span style="color:#2B91AF">Dictionary</span>&lt;<span style="color:blue">string</span>,
+<span style="color:blue">object</span>&gt; symbols = <span style="color:blue">new</span>
+<span style="color:#2B91AF">Dictionary</span>&lt;<span style="color:blue">string</span>,
+<span style="color:blue">object</span>&gt;();<br>
+<span class="SpellE">symbols.Add</span>(<span style="color:#A31515">"x"</span>,
+x);<br>
+<span class="SpellE">symbols.Add</span>(<span style="color:#A31515">"y"</span>,
+y);<br>
+<span style="color:#2B91AF">Expression</span> body = <span class="SpellE"><span style="color:#2B91AF">DynamicExpression</span>.Parse</span>(<span style="color:blue">null</span>, <span style="color:#A31515">"(x + y) *
+2"</span>, symbols);<br>
+<span class="SpellE"><span style="color:#2B91AF">LambdaExpression</span></span> e
+= <span class="SpellE"><span style="color:#2B91AF">Expression</span>.Lambda</span>(<br>
+&nbsp;&nbsp;&nbsp; body, <span style="color:blue">new</span> <span class="SpellE"><span style="color:#2B91AF">ParameterExpression</span></span>[] {
+x, y });</p>
+
+<p class="MsoNormal">Note the use of a <span class="CodeFragment">Dictionary&lt;string,
+object&gt;</span> to provide a dictionary of named <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Substitution_Values">substitution values</a> that can be referenced in
+the expression.</p>
+
+<h2><a name="_Substitution_Values"></a><span style="mso-fareast-font-family:
+&quot;Times New Roman&quot;">Substitution Values<o:p></o:p></span></h2>
+
+<p class="MsoNormal">Several methods in the Dynamic Expression API permit <em><span style="font-family:&quot;Calibri&quot;,&quot;sans-serif&quot;">substitution values</span></em> to
+be specified through a parameter array. Substitution values are referenced in
+an expression using <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Identifiers">identifiers</a> of the form <span class="CodeFragment">@x</span>, where <span class="CodeFragment">x</span> is an
+index into the parameter array. The last element of the parameter array may be
+an object that implements <span class="SpellE"><span class="CodeFragment">IDictionary</span></span><span class="CodeFragment">&lt;string, object&gt;</span>. If so, this dictionary is
+used to map identifiers to substitution values during parsing.</p>
+
+<p class="MsoNormal">An identifier that references a substitution value is
+processed as follows:</p>
+
+<p class="MsoListParagraph" style="text-indent:-.25in"><span style="font-family:
+Symbol">·</span><span style="font-size:7.0pt;line-height:115%;font-family:&quot;Times New Roman&quot;,&quot;serif&quot;">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><span class="GramE">If</span> the value is of type <span class="SpellE"><span class="CodeFragment">System.Linq.Expressions.LambdaExpression</span></span>, the
+identifier must occur as part of a <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Dynamic_Expression_Invocation">dynamic
+lambda invocation</a>. This allows composition of dynamic lambda expressions.</p>
+
+<p class="MsoListParagraph" style="text-indent:-.25in"><span style="font-family:
+Symbol">·</span><span style="font-size:7.0pt;line-height:115%;font-family:&quot;Times New Roman&quot;,&quot;serif&quot;">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>Otherwise, if the value is of type <span class="SpellE"><span class="CodeFragment">System.Linq.Expressions.Expression</span></span>, the given
+expression is substituted for the identifier.</p>
+
+<p class="MsoListParagraph" style="text-indent:-.25in"><span style="font-family:
+Symbol">·</span><span style="font-size:7.0pt;line-height:115%;font-family:&quot;Times New Roman&quot;,&quot;serif&quot;">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>Otherwise, the <span class="SpellE"><span class="CodeFragment">Expression.Constant</span></span><span class="CodeFragment"> </span>method is used to create a constant expression from
+the value which is then substituted for the identifier.</p>
+
+<h2><a name="_Dynamic_Class_Creation"></a><a name="_Dynamic_Data_Classes"></a><span style="mso-fareast-font-family:&quot;Times New Roman&quot;">Dynamic Data Classes<o:p></o:p></span></h2>
+
+<p class="MsoNormal">A data class is a class that contains only data members. The
+<span class="SpellE"><span class="CodeFragment">System.Linq.Dynamic.DynamicExpression</span></span>
+class defines the following methods for dynamically creating data classes.</p>
+
+<p class="Code"><span class="GramE"><span style="color:blue">public</span></span> <span style="color:blue">static</span> <span style="color:#2B91AF">Type</span> <span class="SpellE">CreateClass</span>(<span class="SpellE"><span style="color:blue">params</span></span>
+<span class="SpellE"><span style="color:#2B91AF">DynamicProperty</span></span>[]
+properties);</p>
+
+<p class="Code"><span class="GramE"><span style="color:blue">public</span></span> <span style="color:blue">static</span> <span style="color:#2B91AF">Type</span> <span class="SpellE">CreateClass</span>(<span class="SpellE"><span style="color:#2B91AF">IEnumerable</span></span>&lt;<span class="SpellE"><span style="color:#2B91AF">DynamicProperty</span></span>&gt;
+properties);</p>
+
+<p class="MsoNormal">The <span class="SpellE"><span class="CodeFragment">CreateClass</span></span>
+method creates a new data class with a given set of public properties and
+returns the <span class="SpellE"><span class="CodeFragment">System.Type</span></span>
+object for the newly created class. If a data class with an identical sequence
+of properties has already been created, the <span class="SpellE"><span class="CodeFragment">System.Type</span></span> object for this class is returned.</p>
+
+<p class="MsoNormal">Data classes implement private instance variables and
+read/write property <span class="SpellE">accessors</span> for the specified
+properties. Data classes also override the <span class="CodeFragment">Equals</span>
+and <span class="SpellE"><span class="CodeFragment">GetHashCode</span></span>
+members to implement by-value equality.</p>
+
+<p class="MsoNormal">Data classes are created in an in-memory assembly in the
+current application domain. All data classes inherit from <span class="SpellE"><span class="CodeFragment">System.Linq.Dynamic.DynamicClass</span></span> and are given
+automatically generated names that should be considered private (the names will
+be unique within the application domain but not across multiple invocations of
+the application). Note that once created, a data class stays in memory for the
+lifetime of the current application domain. There is currently no way to unload
+a dynamically created data class.</p>
+
+<p class="MsoNormal">The dynamic expression parser uses the <span class="SpellE"><span class="CodeFragment">CreateClass</span></span> methods to generate classes from <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Anonymous_Object_Initializer">data object initializers</a>. This
+feature in turn is often used with the dynamic <span class="CodeFragment">Select</span>
+method to create projections.</p>
+
+<p class="MsoNormal">The example below uses <span class="SpellE"><span class="CodeFragment">CreateClass</span></span> to create a data class with two
+properties, <span class="CodeFragment">Name</span> and <span class="CodeFragment">Birthday</span>,
+and then uses .NET reflection to create an instance of the class and assign
+values to the properties.</p>
+
+<p class="Code"><span class="SpellE"><span style="color:#2B91AF">DynamicProperty</span></span>[]
+props = <span style="color:blue">new</span> <span class="SpellE"><span style="color:#2B91AF">DynamicProperty</span></span>[] {<br>
+&nbsp;&nbsp;&nbsp; <span style="color:blue">new</span> <span class="SpellE"><span style="color:#2B91AF">DynamicProperty</span></span>(<span style="color:#A31515">"Name"</span>,
+<span class="SpellE"><span style="color:blue">typeof</span></span>(<span style="color:blue">string</span>)),<br>
+&nbsp;&nbsp;&nbsp; <span style="color:blue">new</span> <span class="SpellE"><span style="color:#2B91AF">DynamicProperty</span></span>(<span style="color:#A31515">"Birthday"</span>,
+<span class="SpellE"><span style="color:blue">typeof</span></span>(<span class="SpellE"><span style="color:#2B91AF">DateTime</span></span>)) };<br>
+<span style="color:#2B91AF">Type</span> <span class="SpellE">type</span> = <span class="SpellE"><span style="color:#2B91AF">DynamicExpression</span>.CreateClass</span>(props);<br>
+<span style="color:blue">object</span> <span class="SpellE">obj</span> = <span class="SpellE"><span style="color:#2B91AF">Activator</span>.CreateInstance</span>(type);<br>
+<span class="SpellE">t.GetProperty</span>(<span style="color:#A31515">"Name"</span>).<span class="SpellE">SetValue</span>(<span class="SpellE">obj</span>, <span style="color:#A31515">"Albert"</span>, <span style="color:blue">null</span>);<br>
+<span class="SpellE">t.GetProperty</span>(<span style="color:#A31515">"Birthday"</span>).<span class="SpellE">SetValue</span>(<span class="SpellE">obj</span>, <span style="color:blue">new</span> <span class="SpellE"><span style="color:#2B91AF">DateTime</span></span>(1879,
+3, 14), <span style="color:blue">null</span>);<br>
+<span class="SpellE"><span style="color:#2B91AF">Console</span>.WriteLine</span>(<span class="SpellE">obj</span>);</p>
+
+<h2><a name="_IQueryable_Extension_Methods"></a><span style="mso-fareast-font-family:
+&quot;Times New Roman&quot;">IQueryable Extension Methods<o:p></o:p></span></h2>
+
+<p class="MsoNormal">The <span class="SpellE"><span class="CodeFragment">System.Linq.Dynamic.DynamicQueryable</span></span>
+class implements the following extension methods for dynamically querying
+objects that implement the <span class="CodeFragment">IQueryable&lt;T&gt;</span>
+interface.</p>
+
+<p class="Code"><span class="GramE"><span style="color:blue">public</span></span> <span style="color:blue">static</span> <span style="color:#2B91AF">IQueryable</span>
+Where(<span style="color:blue">this</span> <span style="color:#2B91AF">IQueryable</span>
+source,<br>
+&nbsp;&nbsp;&nbsp; <span style="color:blue">string</span> predicate, <span class="SpellE"><span style="color:blue">params</span></span> <span style="color:blue">object</span>[] values);</p>
+
+<p class="Code"><span class="GramE"><span style="color:blue">public</span></span> <span style="color:blue">static</span> <span style="color:#2B91AF">IQueryable</span>&lt;T&gt;
+Where&lt;T&gt;(<span style="color:blue">this</span> <span style="color:#2B91AF">IQueryable</span>&lt;T&gt;
+source,<br>
+&nbsp;&nbsp;&nbsp; <span style="color:blue">string</span> predicate, <span class="SpellE"><span style="color:blue">params</span></span> <span style="color:blue">object</span>[] values);</p>
+
+<p class="Code"><span class="GramE"><span style="color:blue">public</span></span> <span style="color:blue">static</span> <span style="color:#2B91AF">IQueryable</span>
+Select(<span style="color:blue">this</span> <span style="color:#2B91AF">IQueryable</span>
+source,<br>
+&nbsp;&nbsp;&nbsp; <span style="color:blue">string</span> selector, <span class="SpellE"><span style="color:blue">params</span></span> <span style="color:blue">object</span>[] values);</p>
+
+<p class="Code"><span class="GramE"><span style="color:blue">public</span></span> <span style="color:blue">static</span> <span style="color:#2B91AF">IQueryable</span> <span class="SpellE">OrderBy</span>(<span style="color:blue">this</span> <span style="color:#2B91AF">IQueryable</span> source,<br>
+&nbsp;&nbsp;&nbsp; <span style="color:blue">string</span> ordering, <span class="SpellE"><span style="color:blue">params</span></span> <span style="color:blue">object</span>[] values);</p>
+
+<p class="Code"><span class="GramE"><span style="color:blue">public</span></span> <span style="color:blue">static</span> <span style="color:#2B91AF">IQueryable</span>&lt;T&gt;
+<span class="SpellE">OrderBy</span>&lt;T&gt;(<span style="color:blue">this</span>
+<span style="color:#2B91AF">IQueryable</span>&lt;T&gt; source,<br>
+&nbsp;&nbsp;&nbsp; <span style="color:blue">string</span> ordering, <span class="SpellE"><span style="color:blue">params</span></span> <span style="color:blue">object</span>[] values);</p>
+
+<p class="Code"><span class="GramE"><span style="color:blue">public</span></span> <span style="color:blue">static</span> <span style="color:#2B91AF">IQueryable</span>
+Take(<span style="color:blue">this</span> <span style="color:#2B91AF">IQueryable</span>
+source, <span class="SpellE"><span style="color:blue">int</span></span> count);</p>
+
+<p class="Code"><span class="GramE"><span style="color:blue">public</span></span> <span style="color:blue">static</span> <span style="color:#2B91AF">IQueryable</span>
+Skip(<span style="color:blue">this</span> <span style="color:#2B91AF">IQueryable</span>
+source, <span class="SpellE"><span style="color:blue">int</span></span> count);</p>
+
+<p class="Code"><span class="GramE"><span style="color:blue">public</span></span> <span style="color:blue">static</span> <span style="color:#2B91AF">IQueryable</span> <span class="SpellE">GroupBy</span>(<span style="color:blue">this</span> <span style="color:#2B91AF">IQueryable</span> source,<br>
+&nbsp;&nbsp;&nbsp; <span style="color:blue">string</span> <span class="SpellE">keySelector</span>,
+<span style="color:blue">string</span> <span class="SpellE">elementSelector</span>,
+<span class="SpellE"><span style="color:blue">params</span></span> <span style="color:blue">object</span>[] values);</p>
+
+<p class="Code"><span class="GramE"><span style="color:blue">public</span></span> <span style="color:blue">static</span> <span class="SpellE"><span style="color:blue">bool</span></span>
+Any(<span style="color:blue">this</span> <span style="color:#2B91AF">IQueryable</span>
+source);</p>
+
+<p class="Code"><span class="GramE"><span style="color:blue">public</span></span> <span style="color:blue">static</span> <span class="SpellE"><span style="color:blue">int</span></span>
+Count(<span style="color:blue">this</span> <span style="color:#2B91AF">IQueryable</span>
+source);</p>
+
+<p class="MsoNormal">These methods correspond to their <span class="SpellE"><span class="CodeFragment">System.Linq.Queryable</span></span> counterparts, except
+that they operate on <span class="CodeFragment">IQueryable</span> instead of <span class="CodeFragment">IQueryable&lt;T&gt;</span> and use strings instead of lambda
+expressions to express predicates, selectors, and orderings. <span class="CodeFragment">IQueryable</span> is the non-generic base interface for <span class="CodeFragment">IQueryable&lt;T&gt;</span>, so the methods can be used even
+when <span class="CodeFragment">T</span> isn’t known on beforehand, i.e. when the
+source of a query is dynamically determined. (Note that because a dynamic
+predicate or ordering does not affect the result type, generic overloads are
+provided for <span class="CodeFragment">Where</span> and <span class="SpellE"><span class="CodeFragment">OrderBy</span></span> in order to preserve strong typing
+when possible.)</p>
+
+<p class="MsoNormal">The <span class="CodeFragment">predicate</span>, <span class="CodeFragment">selector</span>, <span class="CodeFragment">ordering</span>, <span class="SpellE"><span class="CodeFragment">keySelector</span></span>, and <span class="SpellE"><span class="CodeFragment">elementSelector</span></span> parameters
+are strings containing expressions written in the <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Expression_Language">expression language</a>. In the expression
+strings, the members of the <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Current_Instance">current instance</a>
+are automatically in scope and the instance itself can be referenced using the
+keyword <span class="CodeFragment">it</span>.</p>
+
+<p class="MsoNormal">The <span class="SpellE"><span class="CodeFragment">OrderBy</span></span>
+method permits a sequence of orderings to be specified, separated by commas.
+Each ordering may optionally be followed by <span class="SpellE"><span class="CodeFragment">asc</span></span> or <span class="CodeFragment">ascending</span>
+to indicate ascending <span class="GramE">order,</span> or <span class="SpellE"><span class="CodeFragment">desc</span></span> or <span class="CodeFragment">descending</span>
+to indicate descending order. The default order is ascending. The example</p>
+
+<p class="Code"><span class="SpellE"><span class="GramE">products.OrderBy</span></span><span class="GramE">(</span><span style="color:#A31515">"<span class="SpellE">Category.CategoryName</span>,
+<span class="SpellE">UnitPrice</span> descending"</span>);</p>
+
+<p class="MsoNormal"><span class="GramE">orders</span> a sequence of products by
+ascending category name and, within each category, descending unit price.</p>
+
+<h2><span style="mso-fareast-font-family:&quot;Times New Roman&quot;">The <span class="SpellE">ParseException</span> Class<o:p></o:p></span></h2>
+
+<p class="MsoNormal">The Dynamic Expression API reports parsing errors using the <span class="SpellE"><span class="CodeFragment">System.Linq.Dynamic.ParseException</span></span>
+class. The <span class="CodeFragment">Position</span> property of the <span class="SpellE"><span class="CodeFragment">ParseException</span></span> class gives
+the character index in the expression string at which the parsing error
+occurred.</p>
+
+<h1><a name="_Expression_Language"></a><span style="mso-fareast-font-family:
+&quot;Times New Roman&quot;">Expression Language<o:p></o:p></span></h1>
+
+<p class="MsoNormal">The expression language implemented by the Dynamic
+Expression API provides a simple and convenient way of writing expressions that
+can be parsed into LINQ expression trees. The language supports most of the
+constructs of expression trees, but it is by no means a complete query or
+programming language. In particular, the expression language does not support
+statements or declarations.</p>
+
+<p class="MsoNormal">The expression language is designed to be familiar to C#,
+VB, and SQL users. For this reason, some operators are present in multiple
+forms, such as <span class="CodeFragment">&amp;&amp;</span> and <span class="SpellE"><span class="CodeFragment">and</span></span>.</p>
+
+<h2><a name="_Identifiers"></a><span style="mso-fareast-font-family:&quot;Times New Roman&quot;">Identifiers<o:p></o:p></span></h2>
+
+<p class="MsoNormal">An Identifier consists of a letter or underscore followed by
+any number of letters, digits, or underscores. In order to reference an
+identifier with the same spelling as a keyword, the identifier must be prefixed
+with a single @ character. Some examples of identifiers:</p>
+
+<p class="Code"><span class="GramE">x</span>&nbsp;&nbsp; Hello&nbsp;&nbsp;
+m_1&nbsp;&nbsp; @true&nbsp;&nbsp; @String</p>
+
+<p class="MsoNormal">Identifiers of the from @x, where x is an integral number
+greater than or equal to zero, are used to denote the <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Substitution_Values">substitution values</a>, if any, that were passed
+to the expression parser. For example:</p>
+
+<p class="Code"><span class="SpellE"><span class="GramE">customers.Where</span></span><span class="GramE">(</span><span style="color:#A31515">"Country = @0"</span>,
+country);</p>
+
+<p class="MsoNormal">Casing is not significant in identifiers or keywords.</p>
+
+<h2><span style="mso-fareast-font-family:&quot;Times New Roman&quot;">Literals<o:p></o:p></span></h2>
+
+<p class="MsoNormal">The expression language supports integer, real, string, and
+character literals.</p>
+
+<p class="MsoNormal">An <em><span style="font-family:&quot;Calibri&quot;,&quot;sans-serif&quot;">integer
+literal</span></em> consists of a sequence of digits. The type of an integer
+literal is the first of the types <span class="CodeFragment">Int32</span>, <span class="CodeFragment">UInt32</span>, <span class="CodeFragment">Int64</span>, or <span class="CodeFragment">UInt64</span> that can represent the given value. An integer
+literal implicitly converts to any other <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#NumericTypes">numeric type</a>
+provided the number is in the range of that type. Some examples of integer
+literals:</p>
+
+<p class="Code">0&nbsp;&nbsp; 123&nbsp;&nbsp; 10000</p>
+
+<p class="MsoNormal">A <em><span style="font-family:&quot;Calibri&quot;,&quot;sans-serif&quot;">real
+literal</span></em> consists of an integral part followed by a fractional part
+and/or an exponent. The integral part is a sequence of one or more digits. The
+fractional part is a decimal point followed by one or more digits. The exponent
+is the letter <span class="CodeFragment">e</span> or <span class="CodeFragment">E</span>
+followed by an optional <span class="CodeFragment">+</span> or <span class="CodeFragment">–</span> sign followed by one or more digits. The type of a
+real literal is <span class="GramE"><span class="CodeFragment">Double</span></span>.
+A real literal implicitly converts to any other <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#RealTypes">real type</a>
+provided the number is in the range of that type. Some examples of real
+literals:</p>
+
+<p class="Code">1.0&nbsp;&nbsp; 2.25 &nbsp;&nbsp;10000.0&nbsp;&nbsp;
+1e0&nbsp;&nbsp; 1e10&nbsp;&nbsp; 1.2345E-4</p>
+
+<p class="MsoNormal">A <em><span style="font-family:&quot;Calibri&quot;,&quot;sans-serif&quot;">string
+literal</span></em> consists of zero or more characters enclosed in double
+quotes. Inside a string literal, a double quote is written as two consecutive
+double quotes. The type of a string literal is <span class="CodeFragment">String</span>.
+Some examples of string literals:</p>
+
+<p class="Code">"<span class="GramE">hello</span>"&nbsp;&nbsp;
+""&nbsp;&nbsp;&nbsp;
+"""quoted"""&nbsp;&nbsp; "'"</p>
+
+<p class="MsoNormal">A <em><span style="font-family:&quot;Calibri&quot;,&quot;sans-serif&quot;">character
+literal</span></em> consists of a single character enclosed in single quotes.
+Inside a character literal, a single quote is written as two consecutive single
+quotes. The type of a character literal is <span class="CodeFragment">Char</span>.
+Some examples of character literals:</p>
+
+<p class="Code">'A'&nbsp;&nbsp; '1'&nbsp;&nbsp; ''''&nbsp;&nbsp; '"'</p>
+
+<h2><span style="mso-fareast-font-family:&quot;Times New Roman&quot;">Constants<o:p></o:p></span></h2>
+
+<p class="MsoNormal">The predefined constants <span class="CodeFragment">true</span>
+and <span class="CodeFragment">false</span> denote the two values of the type <span class="CodeFragment">Boolean</span>.</p>
+
+<p class="MsoNormal">The predefined constant <span class="CodeFragment">null</span>
+denotes a null reference. The <span class="CodeFragment">null</span> constant is
+of type <span class="CodeFragment">Object</span>, but is also implicitly
+convertible to any reference type.</p>
+
+<h2><a name="_Predefined_types"></a><a name="_Types"></a><span style="mso-fareast-font-family:&quot;Times New Roman&quot;">Types<o:p></o:p></span></h2>
+
+<p class="MsoNormal">The expression language defines the following <em><span style="font-family:&quot;Calibri&quot;,&quot;sans-serif&quot;">primitive types</span></em>:</p>
+
+<p class="MsoNormal" style="margin-left:.5in"><span class="CodeFragment">Object</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+<span class="CodeFragment">Boolean</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+<span class="CodeFragment">Char</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+<span class="CodeFragment">String</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+<span class="SpellE"><span class="CodeFragment">SByte</span></span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+<span class="CodeFragment">Byte</span><br>
+<span class="CodeFragment">Int16</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+<span class="CodeFragment">UInt16</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+<span class="CodeFragment">Int32</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+<span class="CodeFragment">UInt32</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+<span class="CodeFragment">Int64</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+<span class="CodeFragment">UInt64</span><br>
+<span class="CodeFragment">Decimal&nbsp;&nbsp;&nbsp;&nbsp; Single</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+<span class="CodeFragment">Double</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+<span class="SpellE"><span class="CodeFragment">DateTime</span></span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+<span class="SpellE"><span class="CodeFragment">TimeSpan</span></span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+<span class="SpellE"><span class="CodeFragment">Guid</span></span></p>
+
+<p class="MsoNormal">The primitive types correspond to the similarly named types
+in the System namespace of the .NET Framework Base Class Library. The
+expression language also defines a set of <em><span style="font-family:&quot;Calibri&quot;,&quot;sans-serif&quot;">accessible
+types</span></em> consisting of the primitive types and the following types
+from the System namespace:</p>
+
+<p class="MsoNormal" style="margin-left:.5in"><span class="CodeFragment">Math</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+<span class="CodeFragment">Convert</span></p>
+
+<p class="MsoNormal">The accessible types are the only types that can be
+explicitly referenced in expressions, and method invocations in the expression
+language are restricted to methods declared in the accessible types.</p>
+
+<p class="MsoNormal">The <span class="SpellE"><em><span style="font-family:&quot;Calibri&quot;,&quot;sans-serif&quot;">nullable</span></em></span><em><span style="font-family:&quot;Calibri&quot;,&quot;sans-serif&quot;"> form</span></em> of a value type is
+referenced by writing <span class="GramE">a <span class="CodeFragment">?</span></span>
+<span class="GramE">after</span> the type name. <span class="GramE">For example, <span class="CodeFragment">Int32?</span></span> <span class="GramE">denotes</span> the <span class="SpellE">nullable</span> form of <span class="CodeFragment">Int32</span>.</p>
+
+<p class="MsoNormal"><a name="IntegralTypes"></a>The non-<span class="SpellE">nullable</span>
+and <span class="SpellE">nullable</span> forms of the types <span class="SpellE"><span class="CodeFragment">SByte</span></span>, <span class="CodeFragment">Byte</span>, <span class="CodeFragment">Int16</span>, <span class="CodeFragment">UInt16</span>, <span class="CodeFragment">Int32</span>, <span class="CodeFragment">UInt32</span>, <span class="CodeFragment">Int64</span>, and <span class="CodeFragment">UInt64</span> are
+collectively called the <em><span style="font-family:&quot;Calibri&quot;,&quot;sans-serif&quot;">integral
+types</span></em>. </p>
+
+<p class="MsoNormal"><a name="_Conversions"></a><a name="RealTypes"></a>The non-<span class="SpellE">nullable</span> and <span class="SpellE">nullable</span> forms of
+the types <span class="CodeFragment">Single</span>, <span class="CodeFragment">Double</span>,
+and <span class="CodeFragment">Decimal</span> are collectively called the <em><span style="font-family:&quot;Calibri&quot;,&quot;sans-serif&quot;">real types</span></em>.</p>
+
+<p class="MsoNormal"><a name="NumericTypes"></a>The integral types and real types
+are collectively called the <em><span style="font-family:&quot;Calibri&quot;,&quot;sans-serif&quot;">numeric
+types</span></em>.</p>
+
+<h2><a name="_Conversions_1"></a><span style="mso-fareast-font-family:&quot;Times New Roman&quot;">Conversions<o:p></o:p></span></h2>
+
+<p class="MsoNormal">The following conversions are implicitly performed by the
+expression language:</p>
+
+<p class="MsoListParagraph" style="text-indent:-.25in"><span style="font-family:
+Symbol">·</span><span style="font-size:7.0pt;line-height:115%;font-family:&quot;Times New Roman&quot;,&quot;serif&quot;">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><span class="GramE">From</span> the <span class="SpellE">the</span> <span class="CodeFragment">null</span> literal to any reference type or <span class="SpellE">nullable</span> type.</p>
+
+<p class="MsoListParagraph" style="text-indent:-.25in"><span style="font-family:
+Symbol">·</span><span style="font-size:7.0pt;line-height:115%;font-family:&quot;Times New Roman&quot;,&quot;serif&quot;">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><span class="GramE">From</span> an integer literal to an <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#IntegralTypes">integral type</a> or <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#RealTypes">real type</a>
+provided the number is within the range of that type.</p>
+
+<p class="MsoListParagraph" style="text-indent:-.25in"><span style="font-family:
+Symbol">·</span><span style="font-size:7.0pt;line-height:115%;font-family:&quot;Times New Roman&quot;,&quot;serif&quot;">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><span class="GramE">From</span> a real literal to a <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#RealTypes">real
+type</a> provided the number is within the range of that type.</p>
+
+<p class="MsoListParagraph" style="text-indent:-.25in"><span style="font-family:
+Symbol">·</span><span style="font-size:7.0pt;line-height:115%;font-family:&quot;Times New Roman&quot;,&quot;serif&quot;">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><span class="GramE">From</span> a string literal to an <span class="SpellE">enum</span>
+type provided the string literal contains the name of a member of that <span class="SpellE">enum</span> type.</p>
+
+<p class="MsoListParagraph" style="text-indent:-.25in"><span style="font-family:
+Symbol">·</span><span style="font-size:7.0pt;line-height:115%;font-family:&quot;Times New Roman&quot;,&quot;serif&quot;">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><span class="GramE">From</span> a source type that is assignment
+compatible with the target type according to the <span class="SpellE"><span class="CodeFragment">Type.IsAssignableFrom</span></span> method in .NET.</p>
+
+<p class="MsoListParagraph" style="text-indent:-.25in"><span style="font-family:
+Symbol">·</span><span style="font-size:7.0pt;line-height:115%;font-family:&quot;Times New Roman&quot;,&quot;serif&quot;">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><span class="GramE">From</span> a non-<span class="SpellE">nullable</span>
+value type to the <span class="SpellE">nullable</span> form of that value type.</p>
+
+<p class="MsoListParagraph" style="text-indent:-.25in"><span style="font-family:
+Symbol">·</span><span style="font-size:7.0pt;line-height:115%;font-family:&quot;Times New Roman&quot;,&quot;serif&quot;">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><span class="GramE">From</span> a <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#NumericTypes">numeric type</a>
+to another numeric type with greater range.</p>
+
+<p class="MsoNormal">The expression language permits explicit conversions using
+the syntax <span class="GramE"><i>type</i><span class="CodeFragment">(</span></span><span class="SpellE"><i>expr</i></span><span class="CodeFragment">)</span>, where <i>type</i>
+is a type name optionally followed by <span class="CodeFragment">?</span> <span class="GramE">and</span> <span class="SpellE"><i>expr</i></span> is an expression.
+This syntax may be used to perform the following conversions:</p>
+
+<p class="MsoListParagraph" style="text-indent:-.25in"><span style="font-family:
+Symbol">·</span><span style="font-size:7.0pt;line-height:115%;font-family:&quot;Times New Roman&quot;,&quot;serif&quot;">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><span class="GramE">Between</span> two types provided <span class="SpellE"><span class="CodeFragment">Type.IsAssignableFrom</span></span> is true in one or both
+directions.</p>
+
+<p class="MsoListParagraph" style="text-indent:-.25in"><span style="font-family:
+Symbol">·</span><span style="font-size:7.0pt;line-height:115%;font-family:&quot;Times New Roman&quot;,&quot;serif&quot;">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><span class="GramE">Between</span> two types provided one or both are
+interface types.</p>
+
+<p class="MsoListParagraph" style="text-indent:-.25in"><span style="font-family:
+Symbol">·</span><span style="font-size:7.0pt;line-height:115%;font-family:&quot;Times New Roman&quot;,&quot;serif&quot;">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span><span class="GramE">Between</span> the <span class="SpellE">nullable</span>
+and non-<span class="SpellE">nullable</span> forms of any value type.</p>
+
+<p class="MsoListParagraph" style="text-indent:-.25in"><span style="font-family:
+Symbol">·</span><span style="font-size:7.0pt;line-height:115%;font-family:&quot;Times New Roman&quot;,&quot;serif&quot;">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>Between any two types belonging to the set consisting of <span class="SpellE"><span class="CodeFragment">SByte</span></span>, <span class="CodeFragment">Byte</span>, <span class="CodeFragment">Int16</span>, <span class="CodeFragment">UInt16</span>, <span class="CodeFragment">Int32</span>, <span class="CodeFragment">UInt32</span>, <span class="CodeFragment">Int64</span>, <span class="CodeFragment">UInt64</span>, <span class="CodeFragment">Decimal</span>, <span class="CodeFragment">Single</span>, <span class="CodeFragment">Double</span>, <span class="CodeFragment">Char</span>, any <span class="SpellE">enum</span> type, as
+well as the <span class="SpellE">nullable</span> forms of those types.</p>
+
+<h2 style="line-height:150%"><span style="mso-fareast-font-family:&quot;Times New Roman&quot;">Operators<o:p></o:p></span></h2>
+
+<p class="MsoNormal">The table below shows the operators supported by the
+expression language in order of precedence from highest to lowest. Operators in
+the same category have equal precedence. In the table, <span class="CodeFragment">x</span>, <span class="CodeFragment">y</span>, and <span class="CodeFragment">z</span> denote expressions, <span class="CodeFragment">T</span>
+denotes a <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Types">type</a>, and <span class="CodeFragment">m</span>
+denotes a member.</p>
+
+<table class="MsoNormalTable" border="0" cellspacing="0" cellpadding="0" style="margin-left:.25in;border-collapse:collapse;mso-yfti-tbllook:1184;
+ mso-padding-alt:0in 0in 0in 0in">
+ <thead>
+  <tr style="mso-yfti-irow:0;mso-yfti-firstrow:yes">
+   <td width="103" valign="top" style="width:77.4pt;border:solid black 1.0pt;
+   background:#D9D9D9;padding:0in 5.4pt 0in 5.4pt">
+   <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+   3.0pt;margin-left:0in;line-height:normal"><b>Category</b></p>
+   </td>
+   <td width="108" valign="top" style="width:81.0pt;border:solid black 1.0pt;
+   border-left:none;background:#D9D9D9;padding:0in 5.4pt 0in 5.4pt">
+   <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+   3.0pt;margin-left:0in;line-height:normal"><b>Expression</b></p>
+   </td>
+   <td width="354" valign="top" style="width:265.5pt;border:solid black 1.0pt;
+   border-left:none;background:#D9D9D9;padding:0in 5.4pt 0in 5.4pt">
+   <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+   3.0pt;margin-left:0in;line-height:normal"><b>Description</b></p>
+   </td>
+  </tr>
+ </thead>
+ <tbody><tr style="mso-yfti-irow:1">
+  <td width="103" rowspan="10" valign="top" style="width:77.4pt;border:solid black 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Primary</p>
+  </td>
+  <td width="108" valign="top" style="width:81.0pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="SpellE"><span class="CodeFragment">x.m</span></span></p>
+  </td>
+  <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Instance field or instance property
+  access. Any public field or property can be accessed.</p>
+  </td>
+ </tr>
+ <tr style="mso-yfti-irow:2">
+  <td width="108" valign="top" style="width:81.0pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="SpellE"><span class="GramE"><span class="CodeFragment">x.m</span></span></span><span class="GramE"><span class="CodeFragment">(</span></span><span class="CodeFragment">…)</span></p>
+  </td>
+  <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Instance <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Constructor_and_Method">method invocation</a>. The method must be
+  public and must be declared in an <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Predefined_types">accessible
+  type</a>.</p>
+  </td>
+ </tr>
+ <tr style="mso-yfti-irow:3">
+  <td width="108" valign="top" style="width:81.0pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="GramE"><span class="CodeFragment">x[</span></span><span class="CodeFragment">…]</span></p>
+  </td>
+  <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Array or indexer access.
+  Multi-dimensional arrays are not supported.</p>
+  </td>
+ </tr>
+ <tr style="mso-yfti-irow:4">
+  <td width="108" valign="top" style="width:81.0pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="SpellE"><span class="CodeFragment">T.m</span></span></p>
+  </td>
+  <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Static field or static property
+  access. Any public field or property can be accessed.</p>
+  </td>
+ </tr>
+ <tr style="mso-yfti-irow:5">
+  <td width="108" valign="top" style="width:81.0pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="SpellE"><span class="GramE"><span class="CodeFragment">T.m</span></span></span><span class="GramE"><span class="CodeFragment">(</span></span><span class="CodeFragment">…)</span></p>
+  </td>
+  <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Static <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Anonymous_Object_Creation">method invocation</a>. The method must be
+  public and must be declared in an <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Predefined_types">accessible
+  type</a>.</p>
+  </td>
+ </tr>
+ <tr style="mso-yfti-irow:6">
+  <td width="108" valign="top" style="width:81.0pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="GramE"><span class="CodeFragment">T(</span></span><span class="CodeFragment">…)</span></p>
+  </td>
+  <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Conversions">Explicit
+  conversion</a> or <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Anonymous_Object_Creation">constructor
+  invocation</a>. Note that <span class="CodeFragment">new</span> is not required
+  in front of a constructor invocation.</p>
+  </td>
+ </tr>
+ <tr style="mso-yfti-irow:7">
+  <td width="108" valign="top" style="width:81.0pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="GramE"><span class="CodeFragment">new(</span></span><span class="CodeFragment">…)</span></p>
+  </td>
+  <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Data_Object_Initializer">Data
+  object <span class="SpellE">initializer</span></a>. This construct can be used
+  to perform dynamic projections.</p>
+  </td>
+ </tr>
+ <tr style="mso-yfti-irow:8">
+  <td width="108" valign="top" style="width:81.0pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="CodeFragment">it</span></p>
+  </td>
+  <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Current_Instance">Current
+  instance</a>. In contexts where members of a current object are implicitly in
+  scope, <span class="CodeFragment">it</span> is used to refer to the entire
+  object itself.</p>
+  </td>
+ </tr>
+ <tr style="mso-yfti-irow:9">
+  <td width="108" valign="top" style="width:81.0pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="GramE"><span class="CodeFragment">x(</span></span><span class="CodeFragment">…)</span></p>
+  </td>
+  <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Dynamic_Expression_Invocation">Dynamic lambda invocation</a>. Used to
+  reference another dynamic lambda expression.</p>
+  </td>
+ </tr>
+ <tr style="mso-yfti-irow:10">
+  <td width="108" valign="top" style="width:81.0pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="SpellE"><span class="CodeFragment">iif</span></span><span class="CodeFragment">(x,</span> <span class="CodeFragment">y,</span> <span class="CodeFragment">z)</span></p>
+  </td>
+  <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Conditional expression. Alternate
+  syntax for <span class="GramE"><span class="CodeFragment">x</span> <span class="CodeFragment">?</span></span> <span class="CodeFragment">y</span> <span class="CodeFragment">:</span> <span class="CodeFragment">z</span>.</p>
+  </td>
+ </tr>
+ <tr style="mso-yfti-irow:11">
+  <td width="103" rowspan="2" valign="top" style="width:77.4pt;border:solid black 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Unary</p>
+  </td>
+  <td width="108" valign="top" style="width:81.0pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="CodeFragment">-x</span></p>
+  </td>
+  <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Negation. Supported types are <span class="CodeFragment">Int32</span>, <span class="CodeFragment">Int64</span>, <span class="CodeFragment">Decimal</span>, <span class="CodeFragment">Single</span>,
+  and <span class="CodeFragment">Double</span>.</p>
+  </td>
+ </tr>
+ <tr style="mso-yfti-irow:12">
+  <td width="108" valign="top" style="width:81.0pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="CodeFragment">!x</span></p>
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="CodeFragment">not x</span></p>
+  </td>
+  <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Logical negation. Operand must be <span class="GramE">of</span> type <span class="CodeFragment">Boolean</span>.</p>
+  </td>
+ </tr>
+ <tr style="mso-yfti-irow:13">
+  <td width="103" rowspan="3" valign="top" style="width:77.4pt;border:solid black 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Multiplicative</p>
+  </td>
+  <td width="108" valign="top" style="width:81.0pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="CodeFragment">x * y</span></p>
+  </td>
+  <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Multiplication. Supported types are
+  <span class="CodeFragment">Int32</span>, <span class="CodeFragment">UInt32</span>,
+  <span class="CodeFragment">Int64</span>, <span class="CodeFragment">UInt64</span>,
+  <span class="CodeFragment">Decimal</span>, <span class="CodeFragment">Single</span>,
+  and <span class="CodeFragment">Double</span>.</p>
+  </td>
+ </tr>
+ <tr style="mso-yfti-irow:14">
+  <td width="108" valign="top" style="width:81.0pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="CodeFragment">x / y</span></p>
+  </td>
+  <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Division. Supported types are <span class="CodeFragment">Int32</span>, <span class="CodeFragment">UInt32</span>, <span class="CodeFragment">Int64</span>, <span class="CodeFragment">UInt64</span>, <span class="CodeFragment">Decimal</span>, <span class="CodeFragment">Single</span>,
+  and <span class="CodeFragment">Double</span>.</p>
+  </td>
+ </tr>
+ <tr style="mso-yfti-irow:15">
+  <td width="108" valign="top" style="width:81.0pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="CodeFragment">x % y</span></p>
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="CodeFragment">x mod y</span></p>
+  </td>
+  <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Remainder. Supported types are <span class="CodeFragment">Int32</span>, <span class="CodeFragment">UInt32</span>, <span class="CodeFragment">Int64</span>, <span class="CodeFragment">UInt64</span>, <span class="CodeFragment">Decimal</span>, <span class="CodeFragment">Single</span>,
+  and <span class="CodeFragment">Double</span>.</p>
+  </td>
+ </tr>
+ <tr style="mso-yfti-irow:16">
+  <td width="103" rowspan="3" valign="top" style="width:77.4pt;border:solid black 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Additive</p>
+  </td>
+  <td width="108" valign="top" style="width:81.0pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="CodeFragment">x + y</span></p>
+  </td>
+  <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Addition or string concatenation.
+  Performs string concatenation if either operand is of type <span class="CodeFragment">String</span>. Otherwise, performs addition for the
+  supported types <span class="CodeFragment">Int32</span>, <span class="CodeFragment">UInt32</span>, <span class="CodeFragment">Int64</span>, <span class="CodeFragment">UInt64</span>, <span class="CodeFragment">Decimal</span>, <span class="CodeFragment">Single</span>, <span class="CodeFragment">Double</span>, <span class="SpellE"><span class="CodeFragment">DateTime</span></span>, and <span class="SpellE"><span class="CodeFragment">TimeSpan</span></span>.</p>
+  </td>
+ </tr>
+ <tr style="mso-yfti-irow:17">
+  <td width="108" valign="top" style="width:81.0pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="CodeFragment">x – y</span></p>
+  </td>
+  <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Subtraction. Supported types are <span class="CodeFragment">Int32</span>, <span class="CodeFragment">UInt32</span>, <span class="CodeFragment">Int64</span>, <span class="CodeFragment">UInt64</span>, <span class="GramE"><span class="CodeFragment">Decimal</span></span>, <span class="CodeFragment">Single</span>, <span class="CodeFragment">Double</span>, <span class="SpellE"><span class="CodeFragment">DateTime</span></span>, and <span class="SpellE"><span class="CodeFragment">TimeSpan</span></span>.</p>
+  </td>
+ </tr>
+ <tr style="mso-yfti-irow:18">
+  <td width="108" valign="top" style="width:81.0pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="CodeFragment">x &amp; y</span></p>
+  </td>
+  <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">String concatenation. Operands may
+  be of any type.</p>
+  </td>
+ </tr>
+ <tr style="mso-yfti-irow:19">
+  <td width="103" rowspan="6" valign="top" style="width:77.4pt;border:solid black 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Relational</p>
+  </td>
+  <td width="108" valign="top" style="width:81.0pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="CodeFragment">x = y</span></p>
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="CodeFragment">x == y</span></p>
+  </td>
+  <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Equal. Supported for reference
+  types and the <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Predefined_types">primitive types</a>. Assignment is
+  not supported.</p>
+  </td>
+ </tr>
+ <tr style="mso-yfti-irow:20">
+  <td width="108" valign="top" style="width:81.0pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="CodeFragment">x != y</span></p>
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="CodeFragment">x &lt;&gt;
+  y</span></p>
+  </td>
+  <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Not equal. Supported for reference
+  types and the <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Predefined_types">primitive types</a>.</p>
+  </td>
+ </tr>
+ <tr style="mso-yfti-irow:21">
+  <td width="108" valign="top" style="width:81.0pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="CodeFragment">x &lt; y</span></p>
+  </td>
+  <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Less than. Supported for all <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Predefined_types">primitive types</a> except <span class="CodeFragment">Boolean</span>, <span class="CodeFragment">Object</span> and
+  <span class="SpellE"><span class="CodeFragment">Guid</span></span>.</p>
+  </td>
+ </tr>
+ <tr style="mso-yfti-irow:22">
+  <td width="108" valign="top" style="width:81.0pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="CodeFragment">x &gt; y</span></p>
+  </td>
+  <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Greater than. Supported for all <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Predefined_types">primitive types</a> except <span class="CodeFragment">Boolean</span>, <span class="CodeFragment">Object</span> and
+  <span class="SpellE"><span class="CodeFragment">Guid</span></span>.</p>
+  </td>
+ </tr>
+ <tr style="mso-yfti-irow:23">
+  <td width="108" valign="top" style="width:81.0pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="CodeFragment">x &lt;= y</span></p>
+  </td>
+  <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Less than or equal. Supported for
+  all <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Predefined_types">primitive types</a> except <span class="CodeFragment">Boolean</span>, <span class="CodeFragment">Object</span> and
+  <span class="SpellE"><span class="CodeFragment">Guid</span></span>.</p>
+  </td>
+ </tr>
+ <tr style="mso-yfti-irow:24">
+  <td width="108" valign="top" style="width:81.0pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="CodeFragment">x &gt;= y</span></p>
+  </td>
+  <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Greater than or equal. Supported
+  for all <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Predefined_types">primitive types</a> except <span class="CodeFragment">Boolean</span>, <span class="CodeFragment">Object</span> and
+  <span class="SpellE"><span class="CodeFragment">Guid</span></span>.</p>
+  </td>
+ </tr>
+ 
+<tr style="mso-yfti-irow:25">
+  <td width="103" valign="top" style="width:77.4pt;border:solid black 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Logical AND</p>
+  </td>
+  <td width="108" valign="top" style="width:81.0pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="CodeFragment">x
+  &amp; y</span></p>
+  </td>
+  <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Logical AND. Operands must support bitwise comparison.</p>
+  </td>
+ </tr>
+<tr style="mso-yfti-irow:25">
+  <td width="103" valign="top" style="width:77.4pt;border:solid black 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Logical XOR</p>
+  </td>
+  <td width="108" valign="top" style="width:81.0pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="CodeFragment">x ^ Y</span></p>
+  </td>
+  <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Logical XOR. Operands must support bitwise comparison.</p>
+  </td>
+ </tr>
+<tr style="mso-yfti-irow:25">
+  <td width="103" valign="top" style="width:77.4pt;border:solid black 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Logical AND</p>
+  </td>
+  <td width="108" valign="top" style="width:81.0pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="CodeFragment">x
+  | y</span></p>
+  </td>
+  <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Logical OR. Operands must support bitwise comparison.</p>
+  </td>
+ </tr><tr style="mso-yfti-irow:25">
+  <td width="103" valign="top" style="width:77.4pt;border:solid black 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Conditional AND</p>
+  </td>
+  <td width="108" valign="top" style="width:81.0pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="CodeFragment">x
+  &amp;&amp; y</span></p>
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="CodeFragment">x and y</span></p>
+  </td>
+  <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Conditional AND. Operands must be <span class="GramE">of</span> type <span class="CodeFragment">Boolean</span>.</p>
+  </td>
+ </tr>
+ <tr style="mso-yfti-irow:26">
+  <td width="103" valign="top" style="width:77.4pt;border:solid black 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Conditional OR</p>
+  </td>
+  <td width="108" valign="top" style="width:81.0pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="CodeFragment">x || y</span></p>
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="CodeFragment">x or y</span></p>
+  </td>
+  <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Conditional OR. Operands must be <span class="GramE">of</span> type <span class="CodeFragment">Boolean</span>.</p>
+  </td>
+ </tr>
+ <tr style="mso-yfti-irow:27;mso-yfti-lastrow:yes">
+  <td width="103" valign="top" style="width:77.4pt;border:solid black 1.0pt;
+  border-top:none;padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Conditional</p>
+  </td>
+  <td width="108" valign="top" style="width:81.0pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal"><span class="GramE"><span class="CodeFragment">x ?</span></span><span class="CodeFragment"> y : z</span></p>
+  </td>
+  <td width="354" valign="top" style="width:265.5pt;border-top:none;border-left:
+  none;border-bottom:solid black 1.0pt;border-right:solid black 1.0pt;
+  padding:0in 5.4pt 0in 5.4pt">
+  <p class="MsoNormal" style="margin-top:3.0pt;margin-right:0in;margin-bottom:
+  3.0pt;margin-left:0in;line-height:normal">Evaluates <span class="CodeFragment">y</span>
+  if <span class="CodeFragment">x</span> is true, evaluates <span class="CodeFragment">z</span> if <span class="CodeFragment">x</span> is false.</p>
+  </td>
+ </tr>
+</tbody></table>
+
+<h2><a name="_Anonymous_Object_Creation"></a><a name="_Constructor_and_Method"></a><span style="mso-fareast-font-family:&quot;Times New Roman&quot;">Method and Constructor
+Invocations<o:p></o:p></span></h2>
+
+<p class="MsoNormal">The expression language limits invocation of methods and
+constructors to those declared public in the <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Predefined_types">accessible
+types</a>. This restriction exists to protect against unintended side effects
+from invocation of arbitrary methods.</p>
+
+<p class="MsoNormal">The expression language permits getting (but not setting)
+the value of any reachable public field, property, or indexer.</p>
+
+<p class="MsoNormal">Overload resolution for methods, constructors, and indexers
+uses rules similar to C#. In informal terms, overload resolution will pick the
+best matching method, constructor, or indexer, or report an ambiguity error if
+no single best match can be identified.</p>
+
+<p class="MsoNormal">Note that constructor invocations are not prefixed by <span class="CodeFragment">new</span>. The following example creates a <span class="SpellE"><span class="CodeFragment">DateTime</span></span> instance for a <span class="SpellE">specfic</span> year, month, and day using a constructor
+invocation:</p>
+
+<p class="Code"><span class="SpellE"><span class="GramE">orders.Where</span></span><span class="GramE">(</span><span style="color:#A31515">"<span class="SpellE">OrderDate</span>
+&gt;= <span class="SpellE">DateTime</span>(2007, 1, 1)"</span>);</p>
+
+<h2><a name="_Anonymous_Object_Initializer"></a><a name="_Data_Object_Initializer"></a><span style="mso-fareast-font-family:&quot;Times New Roman&quot;">Data
+Object Initializers<o:p></o:p></span></h2>
+
+<p class="MsoNormal">A data object <span class="SpellE">initializer</span> creates
+a <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Dynamic_Data_Classes">data class</a> and returns an instance of
+that class. The properties of the data class are inferred from the data object <span class="SpellE">initializer</span>. Specifically, a data object <span class="SpellE">initializer</span> of the form</p>
+
+<p class="Code"><span class="GramE">new(</span>e1 as p1, e2 as p2, e3 as p3)</p>
+
+<p class="MsoNormal"><span class="GramE">creates</span> a data class with three
+properties, <span class="CodeFragment">p1</span>, <span class="CodeFragment">p2</span>,
+and <span class="CodeFragment">p3</span>, the types of which are inferred from
+the expressions <span class="CodeFragment">e1</span>, <span class="CodeFragment">e2</span>,
+and <span class="CodeFragment">e3</span>, and returns an instance of that data
+class with the properties initialized to the values computed by <span class="CodeFragment">e1</span>, <span class="CodeFragment">e2</span>, and <span class="CodeFragment">e3</span>. A property <span class="SpellE">initializer</span>
+may omit the <span class="CodeFragment">as</span> keyword and the property name
+provided the associated expression is a field or property access. The example</p>
+
+<p class="Code"><span class="SpellE"><span class="GramE">customers.Select</span></span><span class="GramE">(</span><span style="color:#A31515">"new(<span class="SpellE">CompanyName</span>
+as Name, Phone)"</span>);</p>
+
+<p class="MsoNormal"><span class="GramE">creates</span> a data class with two
+properties, <span class="CodeFragment">Name</span> and <span class="CodeFragment">Phone</span>,
+and returns a sequence of instances of that data class initialized from the <span class="SpellE"><span class="CodeFragment">CompanyName</span></span> and <span class="CodeFragment">Phone</span> properties of each customer.</p>
+
+<h2><a name="_Current_Instance"></a><span style="mso-fareast-font-family:&quot;Times New Roman&quot;">Current
+Instance<o:p></o:p></span></h2>
+
+<p class="MsoNormal">When parsing a lambda expression with a single unnamed
+parameter, the members of the unnamed parameter are automatically in scope in
+the expression string, and the <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Current_Instance"><em><span style="font-family:&quot;Calibri&quot;,&quot;sans-serif&quot;;color:windowtext;text-decoration:
+none;text-underline:none">current instance</span></em></a> given by the unnamed
+parameter can be referenced in whole using the keyword <span class="CodeFragment">it</span>. For example,</p>
+
+<p class="Code"><span class="SpellE"><span class="GramE">customers.Where</span></span><span class="GramE">(</span><span style="color:#A31515">"Country = @0"</span>,
+country);</p>
+
+<p class="MsoNormal"><span class="GramE">is</span> equivalent to</p>
+
+<p class="Code"><span class="SpellE"><span class="GramE">customers.Where</span></span><span class="GramE">(</span><span style="color:#A31515">"<span class="SpellE">it.Country</span>
+= @0"</span>, country);</p>
+
+<p class="MsoNormal">The <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_IQueryable_Extension_Methods">IQueryable
+extension methods</a> all parse their expression arguments as lambda
+expressions with a single unnamed parameter.</p>
+
+<h2><a name="_Dynamic_Expression_Invocation"></a><span style="mso-fareast-font-family:
+&quot;Times New Roman&quot;">Dynamic Lambda Invocation<o:p></o:p></span></h2>
+
+<p class="MsoNormal">An expression can reference other dynamic lambda expressions
+through <em><span style="font-family:&quot;Calibri&quot;,&quot;sans-serif&quot;">dynamic lambda
+invocations</span></em>. A dynamic lambda invocation consists of a substitution
+variable identifier that references an instance of <span class="SpellE"><span class="CodeFragment">System.Linq.Expressions.LambdaExpression</span></span>,
+followed by an argument list. The arguments supplied must be compatible with
+the parameter list of the given dynamic lambda expression.</p>
+
+<p class="MsoNormal">The following parses two separate dynamic lambda expressions
+and then combines them in a predicate expression through dynamic lambda
+invocations:</p>
+
+<p class="Code"><span style="color:#2B91AF">Expression</span>&lt;<span class="SpellE"><span style="color:#2B91AF">Func</span></span>&lt;<span style="color:#2B91AF">Customer</span>, <span class="SpellE"><span style="color:blue">bool</span></span>&gt;&gt; e1 = <br>
+&nbsp;&nbsp;&nbsp; <span class="SpellE"><span style="color:#2B91AF">DynamicExpression</span>.ParseLambda</span>&lt;<span style="color:#2B91AF">Customer</span>, <span class="SpellE"><span style="color:blue">bool</span></span><span class="GramE">&gt;(</span><span style="color:#A31515">"City = \"London\""</span>);<br>
+<span style="color:#2B91AF">Expression</span>&lt;<span class="SpellE"><span style="color:#2B91AF">Func</span></span>&lt;<span style="color:#2B91AF">Customer</span>,
+<span class="SpellE"><span style="color:blue">bool</span></span>&gt;&gt; e2 =<br>
+&nbsp;&nbsp;&nbsp; <span class="SpellE"><span style="color:#2B91AF">DynamicExpression</span>.ParseLambda</span>&lt;<span style="color:#2B91AF">Customer</span>, <span class="SpellE"><span style="color:blue">bool</span></span>&gt;(<span style="color:#A31515">"<span class="SpellE">Orders.Count</span> &gt;= 10"</span>);<br>
+<span style="color:#2B91AF">IQueryable</span>&lt;<span style="color:#2B91AF">Customer</span>&gt;
+query =<br>
+&nbsp;&nbsp;&nbsp; <span class="SpellE">db.Customers.Where</span>(<span style="color:#A31515">"@0(it) and @1(it)"</span>, e1, e2);</p>
+
+<p class="MsoNormal">It is of course possible to combine static and dynamic
+lambda expressions in this fashion:</p>
+
+<p class="Code"><span style="color:#2B91AF">Expression</span>&lt;<span class="SpellE"><span style="color:#2B91AF">Func</span></span>&lt;<span style="color:#2B91AF">Customer</span>, <span class="SpellE"><span style="color:blue">bool</span></span>&gt;&gt; e1 =<br>
+&nbsp;&nbsp;&nbsp; c =&gt; <span class="SpellE">c.City</span> == <span style="color:#A31515">"London"</span><span class="GramE">;</span><br>
+<span style="color:#2B91AF">Expression</span>&lt;<span class="SpellE"><span style="color:#2B91AF">Func</span></span>&lt;<span style="color:#2B91AF">Customer</span>,
+<span class="SpellE"><span style="color:blue">bool</span></span>&gt;&gt; e2 =<br>
+&nbsp;&nbsp;&nbsp; <span class="SpellE"><span style="color:#2B91AF">DynamicExpression</span>.ParseLambda</span>&lt;<span style="color:#2B91AF">Customer</span>, <span class="SpellE"><span style="color:blue">bool</span></span>&gt;(<span style="color:#A31515">"<span class="SpellE">Orders.Count</span> &gt;= 10"</span>);<br>
+<span style="color:#2B91AF">IQueryable</span>&lt;<span style="color:#2B91AF">Customer</span>&gt;
+query =<br>
+&nbsp;&nbsp;&nbsp; <span class="SpellE">db.Customers.Where</span>(<span style="color:#A31515">"@0(it) and @1(it)"</span>, e1, e2);</p>
+
+<p class="MsoNormal">The examples above both have the same effect as:</p>
+
+<p class="Code"><span style="color:#2B91AF">IQueryable</span>&lt;<span style="color:#2B91AF">Customer</span>&gt; query =<br>
+&nbsp;&nbsp;&nbsp; <span class="SpellE">db.Customers.Where</span>(c =&gt; <span class="SpellE">c.City</span> == <span style="color:#A31515">"London"</span>
+&amp;&amp; <span class="SpellE">c.Orders.Count</span> &gt;= 10)<span class="GramE">;<span style="display:none;mso-hide:all">n</span></span><span style="display:none;
+mso-hide:all"> a predicate expression c lambda expressions and then combines
+them through dynamic lambda invocations</span></p>
+
+<h2><span class="GramE"><span style="mso-fareast-font-family:&quot;Times New Roman&quot;;
+display:none;mso-hide:all">combines</span></span><span style="mso-fareast-font-family:
+&quot;Times New Roman&quot;;display:none;mso-hide:all"> two <span class="SpellE">seperately</span>
+parsed lambda expressions in a single <span class="SpellE">predicate:e</span>
+dynamic lambda expression. <span class="SpellE">System.Linq.Expressions.Lam<span style="mso-hide:none">Sequence</span></span></span><span style="mso-fareast-font-family:
+&quot;Times New Roman&quot;"> operators<o:p></o:p></span></h2>
+
+<p class="MsoNormal">A subset of the Standard Query Operators is supported for
+objects that implement <span class="SpellE"><span class="CodeFragment">IEnumerable</span></span><span class="CodeFragment">&lt;T&gt;</span>. Specifically, the following constructs are
+permitted, where <span class="SpellE"><i>seq</i></span> is an <span class="SpellE"><span class="CodeFragment">IEnumerable</span></span><span class="CodeFragment">&lt;T&gt;</span>
+instance, <i>predicate</i> is a <span class="SpellE"><span class="GramE">boolean</span></span>
+expression, and <i>selector</i> is an expression of any type:</p>
+
+<p class="MsoNormal" style="margin-left:.5in"><span class="SpellE"><span class="GramE"><em><span style="font-family:&quot;Calibri&quot;,&quot;sans-serif&quot;">seq</span></em></span></span><span class="GramE"> <span class="CodeFragment">.</span></span> <span class="CodeFragment">Where</span>
+<span class="GramE"><span class="CodeFragment">(</span> <em><span style="font-family:
+&quot;Calibri&quot;,&quot;sans-serif&quot;">predicate</span></em></span> <span class="CodeFragment">)</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+<span class="SpellE"><em><span style="font-family:&quot;Calibri&quot;,&quot;sans-serif&quot;">seq</span></em></span>
+<span class="CodeFragment">.</span> <span class="CodeFragment">Any</span> <span class="CodeFragment">(</span> <span class="CodeFragment">)</span></p>
+
+<p class="MsoNormal" style="margin-left:.5in"><span class="SpellE"><span class="GramE"><em><span style="font-family:&quot;Calibri&quot;,&quot;sans-serif&quot;">seq</span></em></span></span><span class="GramE"> <span class="CodeFragment">.</span></span> <span class="CodeFragment">Any</span>
+<span class="GramE"><span class="CodeFragment">(</span> <em><span style="font-family:
+&quot;Calibri&quot;,&quot;sans-serif&quot;">predicate</span></em></span> <span class="CodeFragment">)</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+<span class="SpellE"><em><span style="font-family:&quot;Calibri&quot;,&quot;sans-serif&quot;">seq</span></em></span>
+<span class="CodeFragment">.</span> <span class="CodeFragment">All</span> <span class="GramE"><span class="CodeFragment">(</span> <em><span style="font-family:
+&quot;Calibri&quot;,&quot;sans-serif&quot;">predicate</span></em></span> )</p>
+
+<p class="MsoNormal" style="margin-left:.5in"><span class="SpellE"><span class="GramE"><em><span style="font-family:&quot;Calibri&quot;,&quot;sans-serif&quot;">seq</span></em></span></span><span class="GramE"> <span class="CodeFragment">.</span></span> <span class="CodeFragment">Count</span>
+<span class="CodeFragment">(</span> <span class="CodeFragment">)</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+<span class="SpellE"><span class="GramE"><em><span style="font-family:&quot;Calibri&quot;,&quot;sans-serif&quot;">seq</span></em></span></span><span class="GramE"> <span class="CodeFragment">.</span></span> <span class="CodeFragment">Count</span>
+<span class="GramE"><span class="CodeFragment">(</span> <em><span style="font-family:
+&quot;Calibri&quot;,&quot;sans-serif&quot;">predicate</span></em></span> <span class="CodeFragment">)</span></p>
+
+<p class="MsoNormal" style="margin-left:.5in"><span class="SpellE"><span class="GramE"><em><span style="font-family:&quot;Calibri&quot;,&quot;sans-serif&quot;">seq</span></em></span></span><span class="GramE"> <span class="CodeFragment">.</span></span> <span class="CodeFragment">Min</span>
+<span class="GramE"><span class="CodeFragment">(</span> <em><span style="font-family:
+&quot;Calibri&quot;,&quot;sans-serif&quot;">selector</span></em></span> <span class="CodeFragment">)</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+<span class="SpellE"><em><span style="font-family:&quot;Calibri&quot;,&quot;sans-serif&quot;">seq</span></em></span>
+<span class="CodeFragment">.</span> <span class="CodeFragment">Max</span> <span class="GramE"><span class="CodeFragment">(</span> <em><span style="font-family:
+&quot;Calibri&quot;,&quot;sans-serif&quot;">selector</span></em></span> <span class="CodeFragment">)</span></p>
+
+<p class="MsoNormal" style="margin-left:.5in"><span class="SpellE"><span class="GramE"><em><span style="font-family:&quot;Calibri&quot;,&quot;sans-serif&quot;">seq</span></em></span></span><span class="GramE"> <span class="CodeFragment">.</span></span> <span class="CodeFragment">Sum</span>
+<span class="GramE"><span class="CodeFragment">(</span> <em><span style="font-family:
+&quot;Calibri&quot;,&quot;sans-serif&quot;">selector</span></em></span> <span class="CodeFragment">)</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+<span class="SpellE"><em><span style="font-family:&quot;Calibri&quot;,&quot;sans-serif&quot;">seq</span></em></span>
+<span class="CodeFragment">.</span> <span class="CodeFragment">Average</span> <span class="GramE"><span class="CodeFragment">(</span> <em><span style="font-family:
+&quot;Calibri&quot;,&quot;sans-serif&quot;">selector</span></em></span> <span class="CodeFragment">)</span></p>
+
+<p class="MsoNormal">In the <i>predicate</i> and <i>selector</i> expressions, the
+members of the <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Current_Instance">current instance</a> for that
+sequence operator are automatically in scope, and the instance itself can be
+referenced using the keyword <span class="CodeFragment">it</span>. An example:</p>
+
+<p class="Code"><span class="SpellE"><span class="GramE">customers.Where</span></span><span class="GramE">(</span><span style="color:#A31515">"<span class="SpellE">Orders.Any</span>(Total
+&gt;= 1000)"</span>);</p>
+
+<h2><span class="SpellE"><span style="mso-fareast-font-family:&quot;Times New Roman&quot;">Enum</span></span><span style="mso-fareast-font-family:&quot;Times New Roman&quot;"> type support<o:p></o:p></span></h2>
+
+<p class="MsoNormal">The expression language supports an <a href="file:///D:/Projects/GitRepos/System.Linq.Dynamic/Dynamic%20Expressions.html#_Conversions_1">implicit
+conversion</a> from a string literal to an <span class="SpellE">enum</span> type
+provided the string literal contains the name of a member of that <span class="SpellE">enum</span> type. For example,</p>
+
+<p class="Code"><span class="SpellE"><span class="GramE">orders.Where</span></span><span class="GramE">(</span><span style="color:#A31515">"<span class="SpellE">OrderDate.DayOfWeek</span>
+= \"Monday\""</span>);</p>
+
+<p class="MsoNormal"><span class="GramE">is</span> equivalent to</p>
+
+<p class="Code"><span class="SpellE"><span class="GramE">orders.Where</span></span><span class="GramE">(</span><span style="color:#A31515">"<span class="SpellE">OrderDate.DayOfWeek</span>
+= @0"</span>, <span class="SpellE"><span style="color:#2B91AF">DayOfWeek</span>.Monday</span>);</p>
+
+<p class="MsoNormal">&nbsp;</p>
+
+</div>
+
+
+
+
+</body></html>

--- a/Src/System.Linq.Dynamic/DynamicLinq.cs
+++ b/Src/System.Linq.Dynamic/DynamicLinq.cs
@@ -596,6 +596,7 @@ namespace System.Linq.Dynamic
             Exclamation,
             Percent,
             Ampersand,
+            AmpersandB,
             OpenParen,
             CloseParen,
             Asterisk,
@@ -946,7 +947,7 @@ namespace System.Linq.Dynamic
         Expression ParseLogicalAnd()
         {
             Expression left = ParseComparison();
-            while (token.id == TokenId.Ampersand)//token.id == TokenId.BAmpersand)
+            while (token.id == TokenId.AmpersandB)//token.id == TokenId.BAmpersand)
             {
                 Token op = token;
                 NextToken();
@@ -1057,7 +1058,7 @@ namespace System.Linq.Dynamic
         Expression ParseAdditive()
         {
             Expression left = ParseMultiplicative();
-            while (token.id == TokenId.Plus || token.id == TokenId.Minus)
+            while (token.id == TokenId.Plus || token.id == TokenId.Minus || token.id == TokenId.Ampersand)
             {
                 Token op = token;
                 NextToken();
@@ -1066,7 +1067,7 @@ namespace System.Linq.Dynamic
                 {
                     case TokenId.Plus:
                         if (left.Type == typeof(string) || right.Type == typeof(string))
-                            goto case TokenId.Unknown;
+                            goto case TokenId.Ampersand;
                         CheckAndPromoteOperands(typeof(IAddSignatures), op.text, ref left, ref right, op.pos);
                         left = GenerateAdd(left, right);
                         break;
@@ -1074,7 +1075,7 @@ namespace System.Linq.Dynamic
                         CheckAndPromoteOperands(typeof(ISubtractSignatures), op.text, ref left, ref right, op.pos);
                         left = GenerateSubtract(left, right);
                         break;
-                    case TokenId.Unknown:
+                    case TokenId.Ampersand:
                         left = GenerateStringConcat(left, right);
                         break;
                 }
@@ -2247,6 +2248,10 @@ namespace System.Linq.Dynamic
                     {
                         NextChar();
                         t = TokenId.DoubleAmpersand;
+                    } else if (ch == 'b')
+                    {
+                        NextChar();
+                        t = TokenId.AmpersandB;
                     }
                     else
                     {

--- a/Src/System.Linq.Dynamic/DynamicLinq.cs
+++ b/Src/System.Linq.Dynamic/DynamicLinq.cs
@@ -595,7 +595,7 @@ namespace System.Linq.Dynamic
             RealLiteral,
             Exclamation,
             Percent,
-            Amphersand,
+            Ampersand,
             OpenParen,
             CloseParen,
             Asterisk,
@@ -613,12 +613,13 @@ namespace System.Linq.Dynamic
             CloseBracket,
             Bar,
             ExclamationEqual,
-            DoubleAmphersand,
+            DoubleAmpersand,
             LessThanEqual,
             LessGreater,
             DoubleEqual,
             GreaterThanEqual,
-            DoubleBar
+            DoubleBar,
+            Caret,
         }
 
         interface ILogicalSignatures
@@ -868,7 +869,7 @@ namespace System.Linq.Dynamic
         Expression ParseExpression()
         {
             int errorPos = token.pos;
-            Expression expr = ParseLogicalOr();
+            Expression expr = ParseConditionalOr();
             if (token.id == TokenId.Question)
             {
                 NextToken();
@@ -882,14 +883,14 @@ namespace System.Linq.Dynamic
         }
 
         // ||, or operator
-        Expression ParseLogicalOr()
+        Expression ParseConditionalOr()
         {
-            Expression left = ParseLogicalAnd();
+            Expression left = ParseConditionalAnd();
             while (token.id == TokenId.DoubleBar || TokenIdentifierIs("or"))
             {
                 Token op = token;
                 NextToken();
-                Expression right = ParseLogicalAnd();
+                Expression right = ParseConditionalAnd();
                 CheckAndPromoteOperands(typeof(ILogicalSignatures), op.text, ref left, ref right, op.pos);
                 left = Expression.OrElse(left, right);
             }
@@ -897,16 +898,61 @@ namespace System.Linq.Dynamic
         }
 
         // &&, and operator
+        Expression ParseConditionalAnd()
+        {
+            Expression left = ParseLogicalOr();
+            while (token.id == TokenId.DoubleAmpersand || TokenIdentifierIs("and"))
+            {
+                Token op = token;
+                NextToken();
+                Expression right = ParseLogicalOr();
+                CheckAndPromoteOperands(typeof(ILogicalSignatures), op.text, ref left, ref right, op.pos);
+                left = Expression.AndAlso(left, right);
+            }
+            return left;
+        }
+
+
+        // | operator
+        Expression ParseLogicalOr()
+        {
+            Expression left = ParseLogicalXor();
+            while (token.id == TokenId.Bar)
+            {
+                Token op = token;
+                NextToken();
+                Expression right = ParseLogicalXor();
+                CheckAndPromoteOperands(typeof(IArithmeticSignatures), op.text, ref left, ref right, op.pos);
+                left = Expression.Or(left, right);
+            }
+            return left;
+        }
+        // ^ operator
+        Expression ParseLogicalXor()
+        {
+            Expression left = ParseLogicalAnd();
+            while (token.id == TokenId.Caret)
+            {
+                Token op = token;
+                NextToken();
+                Expression right = ParseLogicalAnd();
+                CheckAndPromoteOperands(typeof(IArithmeticSignatures), op.text, ref left, ref right, op.pos);
+                left = Expression.ExclusiveOr(left, right);
+            }
+            return left;
+        }
+
+        // & operator
         Expression ParseLogicalAnd()
         {
             Expression left = ParseComparison();
-            while (token.id == TokenId.DoubleAmphersand || TokenIdentifierIs("and"))
+            while (token.id == TokenId.Ampersand)//token.id == TokenId.BAmpersand)
             {
                 Token op = token;
                 NextToken();
                 Expression right = ParseComparison();
-                CheckAndPromoteOperands(typeof(ILogicalSignatures), op.text, ref left, ref right, op.pos);
-                left = Expression.AndAlso(left, right);
+                CheckAndPromoteOperands(typeof(IArithmeticSignatures), op.text, ref left, ref right, op.pos);
+                left = Expression.And(left, right);
             }
             return left;
         }
@@ -1007,12 +1053,11 @@ namespace System.Linq.Dynamic
             return left;
         }
 
-        // +, -, & operators
+        // +, - operators
         Expression ParseAdditive()
         {
             Expression left = ParseMultiplicative();
-            while (token.id == TokenId.Plus || token.id == TokenId.Minus ||
-                token.id == TokenId.Amphersand)
+            while (token.id == TokenId.Plus || token.id == TokenId.Minus)
             {
                 Token op = token;
                 NextToken();
@@ -1021,7 +1066,7 @@ namespace System.Linq.Dynamic
                 {
                     case TokenId.Plus:
                         if (left.Type == typeof(string) || right.Type == typeof(string))
-                            goto case TokenId.Amphersand;
+                            goto case TokenId.Unknown;
                         CheckAndPromoteOperands(typeof(IAddSignatures), op.text, ref left, ref right, op.pos);
                         left = GenerateAdd(left, right);
                         break;
@@ -1029,7 +1074,7 @@ namespace System.Linq.Dynamic
                         CheckAndPromoteOperands(typeof(ISubtractSignatures), op.text, ref left, ref right, op.pos);
                         left = GenerateSubtract(left, right);
                         break;
-                    case TokenId.Amphersand:
+                    case TokenId.Unknown:
                         left = GenerateStringConcat(left, right);
                         break;
                 }
@@ -2201,12 +2246,16 @@ namespace System.Linq.Dynamic
                     if (ch == '&')
                     {
                         NextChar();
-                        t = TokenId.DoubleAmphersand;
+                        t = TokenId.DoubleAmpersand;
                     }
                     else
                     {
-                        t = TokenId.Amphersand;
+                        t = TokenId.Ampersand;
                     }
+                    break;
+                case '^':
+                    NextChar();
+                    t = TokenId.Caret;
                     break;
                 case '(':
                     NextChar();


### PR DESCRIPTION
Implementing logical operators in accordance with precedence given at https://msdn.microsoft.com/en-us/library/6a71f45d.aspx
The use of &b instead of & is made to ensure backwards compatibility for developers that currently use it as concatenation operator. The other operators, | and ^ where not in use and can be used without postfix.