### PR TITLE
Added select aggregate function

### DIFF
--- a/Src/System.Linq.Dynamic/DynamicLinq.cs
+++ b/Src/System.Linq.Dynamic/DynamicLinq.cs
@@ -731,6 +731,7 @@ namespace System.Linq.Dynamic
             void Average(double? selector);
             void Average(decimal selector);
             void Average(decimal? selector);
+            void Select(object selector);
         }
 
         static readonly Type[] predefinedTypes = {
@@ -1493,7 +1494,7 @@ namespace System.Linq.Dynamic
             if (FindMethod(typeof(IEnumerableSignatures), methodName, false, args, out signature) != 1)
                 throw ParseError(errorPos, Res.NoApplicableAggregate, methodName);
             Type[] typeArgs;
-            if (signature.Name == "Min" || signature.Name == "Max")
+            if (signature.Name == "Min" || signature.Name == "Max"|| signature.Name == "Select")
             {
                 typeArgs = new Type[] { elementType, args[0].Type };
             }


### PR DESCRIPTION
Added select aggregate function to solve problem outlined here: http://stackoverflow.com/questions/31322202/how-can-i-use-dynamic-linq-to-project-sub-collections

Feature allows you to do the equivalent of :  

var locations = Locations.Select(l => new {l.ID, Emps = l.Employees.Select(e=>e.FirstName)}); 

with the following dynamic syntax:

"new(ID,Employees.Select(new(FirstName)) as Employees)"

which results in a list of locations, where each location object has an ID and a list of employees, each of which containing FirstName