### PR TITLE
Fixed #44. Removed unnecessary return type check from member method access.

### DIFF
--- a/Src/System.Linq.Dynamic.Test/DynamicExpressionTests.cs
+++ b/Src/System.Linq.Dynamic.Test/DynamicExpressionTests.cs
@@ -15,5 +15,16 @@ namespace System.Linq.Dynamic.Test
                 "it.ToString()");
             Assert.AreEqual(typeof(string), expression.ReturnType);
         }
+
+        [TestMethod]
+        public void ParseLambda_VoidMethodCall_ReturnsActionDelegate()
+        {
+            var expression = DynamicExpression.ParseLambda(
+                typeof(System.IO.FileStream),
+                null,
+                "it.Close()");
+            Assert.AreEqual(typeof(void), expression.ReturnType);
+            Assert.AreEqual(typeof(Action<System.IO.FileStream>), expression.Type);
+        }
     }
 }

--- a/Src/System.Linq.Dynamic/DynamicLinq.cs
+++ b/Src/System.Linq.Dynamic/DynamicLinq.cs
@@ -1441,11 +1441,7 @@ namespace System.Linq.Dynamic
                         throw ParseError(errorPos, Res.NoApplicableMethod,
                             id, GetTypeName(type));
                     case 1:
-                        MethodInfo method = (MethodInfo)mb;
-                        if (method.ReturnType == typeof(void))
-                            throw ParseError(errorPos, Res.MethodIsVoid,
-                                id, GetTypeName(method.DeclaringType));
-                        return Expression.Call(instance, (MethodInfo)method, args);
+                        return Expression.Call(instance, (MethodInfo)mb, args);
                     default:
                         throw ParseError(errorPos, Res.AmbiguousMethodInvocation,
                             id, GetTypeName(type));


### PR DESCRIPTION
This pull-request also fixes most of the pipeline for parsing `Action<>` delegates. It turns out `Expression.Lambda` is smart enough to realize that if the input expression returns `void`, it should output an `Action<>` delegate.

I've also included a unit test to demonstrate this. This would be a really powerful addition for scripted expresssions.