### PR TITLE
Fixed #42. Added ParseLambda overload to allow specifying the delegate type.

### DIFF
--- a/Src/System.Linq.Dynamic.Test/DynamicExpressionTests.cs
+++ b/Src/System.Linq.Dynamic.Test/DynamicExpressionTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq.Expressions;
 
 namespace System.Linq.Dynamic.Test
 {
@@ -14,6 +15,20 @@ namespace System.Linq.Dynamic.Test
                 typeof(string),
                 "it.ToString()");
             Assert.AreEqual(typeof(string), expression.ReturnType);
+        }
+
+        [TestMethod]
+        public void ParseLambda_DelegateTypeMethodCall_ReturnsEventHandlerLambdaExpression()
+        {
+            var expression = DynamicExpression.ParseLambda(
+                typeof(EventHandler),
+                new[] { Expression.Parameter(typeof(object), "sender"),
+                        Expression.Parameter(typeof(EventArgs), "e") },
+                null,
+                "sender.ToString()");
+
+            Assert.AreEqual(typeof(void), expression.ReturnType);
+            Assert.AreEqual(typeof(EventHandler), expression.Type);
         }
     }
 }

--- a/Src/System.Linq.Dynamic/DynamicLinq.cs
+++ b/Src/System.Linq.Dynamic/DynamicLinq.cs
@@ -323,6 +323,12 @@ namespace System.Linq.Dynamic
             return Expression.Lambda(parser.Parse(resultType), parameters);
         }
 
+        public static LambdaExpression ParseLambda(Type delegateType, ParameterExpression[] parameters, Type resultType, string expression, params object[] values)
+        {
+            ExpressionParser parser = new ExpressionParser(parameters, expression, values);
+            return Expression.Lambda(delegateType, parser.Parse(resultType), parameters);
+        }
+
         public static Expression<Func<T, S>> ParseLambda<T, S>(string expression, params object[] values)
         {
             return (Expression<Func<T, S>>)ParseLambda(typeof(T), typeof(S), expression, values);


### PR DESCRIPTION
Added proposed implementation and corresponding unit tests.