### PR TITLE
Fix the multi-threading issue at ClassFactory.GetDynamicClass

### DIFF
--- a/Src/System.Linq.Dynamic.Test/DynamicExpressionTests.cs
+++ b/Src/System.Linq.Dynamic.Test/DynamicExpressionTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace System.Linq.Dynamic.Test
@@ -14,6 +16,23 @@ namespace System.Linq.Dynamic.Test
                 typeof(string),
                 "it.ToString()");
             Assert.AreEqual(typeof(string), expression.ReturnType);
+        }
+
+        [TestMethod]
+        public void CreateClass_TheadSafe()
+        {
+            const int numOfTasks = 15;
+
+            var properties = new[] { new DynamicProperty("prop1", typeof(string)) };
+
+            var tasks = new List<Task>(numOfTasks);
+
+            for (var i = 0; i < numOfTasks; i++)
+            {
+                tasks.Add(Task.Factory.StartNew(() => DynamicExpression.CreateClass(properties)));
+            }
+
+            Task.WaitAll(tasks.ToArray());
         }
     }
 }


### PR DESCRIPTION
The classes.Add(signature, type) is now placed within the writer lock, thus avoid multiple threads from updating the classes dictionary at the same time.

The issue is also mentioned here: http://stackoverflow.com/questions/7156181/system-linq-dynamic-selectnew-does-not-appear-to-be-thread-safe